### PR TITLE
Регистрация пользователя в хэндлере /start

### DIFF
--- a/src/bot/constants/commands.py
+++ b/src/bot/constants/commands.py
@@ -1,0 +1,1 @@
+COMMAND__GREETING = "choose_category_after_start"

--- a/src/bot/constants/states.py
+++ b/src/bot/constants/states.py
@@ -1,0 +1,1 @@
+GREETING = "greeting"

--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -1,9 +1,36 @@
-from telegram import Update
+import contextlib
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
+from src.bot.constants import commands, states
+from src.core.db.db import get_session
+from src.core.services.user import UserService
 
-async def start_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+
+async def start_callback(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+):
+    get_async_session_context = contextlib.asynccontextmanager(get_session)
+    async with get_async_session_context() as session:
+        user_service = UserService(session)
+        await user_service.register_user(
+            telegram_id=update.effective_chat.id,
+            username=update.effective_chat.username,
+        )
+    callback_data = commands.COMMAND__GREETING
+    button = [[InlineKeyboardButton(text="Начнём", callback_data=callback_data)]]
+    keyboard = InlineKeyboardMarkup(button)
     await context.bot.send_message(
         chat_id=update.effective_chat.id,
-        text="Привет! Это бот платформы интеллектуального волонтерства " "ProCharity",
+        text="Привет! 👋 \n\n"
+        'Я бот платформы интеллектуального волонтерства <a href="https://procharity.ru/">ProCharity</a>. '
+        "Буду держать тебя в курсе новых задач и помогу "
+        "оперативно связаться с командой поддержки.",
+        reply_markup=keyboard,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
     )
+    return states.GREETING

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -1,0 +1,17 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.db.models import User
+from src.core.db.repository.base import AbstractRepository
+
+
+class UserRepository(AbstractRepository):
+    """Репозиторий для работы с моделью User."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session, User)
+
+    async def get_by_telegram_id(self, telegram_id: int) -> User | None:
+        """Возвращает пользователя (или None) по telegram_id."""
+        user = await self._session.execute(select(User).where(User.telegram_id == telegram_id))
+        return user.scalars().first()

--- a/src/core/services/user.py
+++ b/src/core/services/user.py
@@ -1,0 +1,31 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.db.models import User
+from src.core.db.repository.user import UserRepository
+
+
+class UserService:
+    def __init__(self, session: AsyncSession):
+        self.__user_repository = UserRepository(session)
+
+    async def register_user(self, telegram_id: int, username: str = "") -> None:
+        """Регистрирует нового пользователя по telegram_id.
+
+        Если пользователь найден, обновляет имя и флаг "заблокирован".
+        """
+        user = await self.__user_repository.get_by_telegram_id(telegram_id)
+        if user is not None:
+            user_changed = False
+            if user.username != username:
+                user.username = username
+                user_changed = True
+            if user.banned:
+                user.banned = False
+                user_changed = True
+            if user_changed:
+                await self.__user_repository.update(user.id, user)
+            return None
+        user = User()
+        user.telegram_id = telegram_id
+        user.username = username
+        await self.__user_repository.create(user)


### PR DESCRIPTION
Переписан хэндлер /start - добавлена регистрация пользователя.
Пользователь проверяется по telegram_id, и если уже был, то при изменении username оно обновляется, а также если был установлен флаг banned, он сбрасывается в false (т.е., отправив /start, пользователь снова разрешает боту отправлять ему сообщения).