### PR TITLE
пофиксен баг с урлом feedback-form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Переменные приложения
 BOT_TOKEN= # Токен аутентификации бота
-APPLICATION_URL=  # Домен, на котором развернуто приложение
+APPLICATION_URL=procharity.duckdns.org  # Домен, на котором развернуто приложение
 BOT_WEBHOOK_MODE=False  # Запустить бота в режиме webhook(True) | polling(False)
 HEALTHCHECK_API_URL=http://127.0.0.1:8080/docs  # Эндпоинт для проверки API
 DEBUG=False  # Включение(True) | Выключение(False) режима отладки

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
     APPLICATION_URL: str = "localhost"
     SECRET_KEY: str = "secret_key"
-    ROOT_PATH: str = "/api/"
+    ROOT_PATH: str = "/api"
     DEBUG: bool = False
     USE_NGROK: bool = False
 
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
 
     @property
     def api_url(self) -> str:
-        return urljoin(self.APPLICATION_URL, self.ROOT_PATH)
+        return urljoin(self.APPLICATION_URL, self.ROOT_PATH + "/")
 
     @property
     def telegram_webhook_url(self) -> str:


### PR DESCRIPTION
Задача:
https://www.notion.so/968c90aa11df47759256848cc18e0e4f?pvs=4

Решена проблема с тройным слэшом в методе `def api_url` в `settings.py`

Добавил домен APPLICATION_URL в `env.example`. 
Форма обратной связи теперь приходит в телегу, но не уверен можно ли светить домен в `env.example`. Другого способа не нашел. 

В самой форме не хватает поля для текста с описанием вопроса/проблемы

![image](https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/assets/103027888/83e9ca2e-4cba-4d0a-8c22-9bc8636e5bca)

