### PR TITLE
fix/removing-messages-once-pushed

### DIFF
--- a/src/bot/handlers/categories.py
+++ b/src/bot/handlers/categories.py
@@ -6,12 +6,12 @@ from src.bot.constants import callback_data
 from src.bot.keyboards import get_categories_keyboard, get_open_tasks_and_menu_keyboard
 from src.bot.services.category import CategoryService
 from src.bot.services.user import UserService
-from src.bot.utils import delete_previous
+from src.bot.utils import delete_previous_message
 from src.core.logging.utils import logger_decor
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def categories_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_service = UserService()
     category_service = CategoryService()

--- a/src/bot/handlers/categories.py
+++ b/src/bot/handlers/categories.py
@@ -6,10 +6,12 @@ from src.bot.constants import callback_data
 from src.bot.keyboards import get_categories_keyboard, get_open_tasks_and_menu_keyboard
 from src.bot.services.category import CategoryService
 from src.bot.services.user import UserService
+from src.bot.utils import delete_previous
 from src.core.logging.utils import logger_decor
 
 
 @logger_decor
+@delete_previous
 async def categories_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_service = UserService()
     category_service = CategoryService()

--- a/src/bot/handlers/menu.py
+++ b/src/bot/handlers/menu.py
@@ -19,6 +19,7 @@ from src.api.schemas import FeedbackFormQueryParams
 from src.bot.constants import callback_data, commands, enum, patterns
 from src.bot.keyboards import get_back_menu, get_menu_keyboard, get_no_mailing_keyboard
 from src.bot.services.user import UserService
+from src.bot.utils import delete_previous
 from src.core.logging.utils import logger_decor
 from src.settings import settings
 
@@ -26,6 +27,7 @@ log = structlog.get_logger()
 
 
 @logger_decor
+@delete_previous
 async def menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Возвращает в меню."""
     await context.bot.send_message(
@@ -36,6 +38,7 @@ async def menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 @logger_decor
+@delete_previous
 async def set_mailing(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Включение/выключение подписки пользователя на почтовую рассылку."""
     telegram_id = update.effective_user.id
@@ -118,6 +121,7 @@ async def web_app_data(update: Update):
 
 
 @logger_decor
+@delete_previous
 async def about_project(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await context.bot.send_message(
         chat_id=update.effective_chat.id,

--- a/src/bot/handlers/menu.py
+++ b/src/bot/handlers/menu.py
@@ -19,7 +19,7 @@ from src.api.schemas import FeedbackFormQueryParams
 from src.bot.constants import callback_data, commands, enum, patterns
 from src.bot.keyboards import get_back_menu, get_menu_keyboard, get_no_mailing_keyboard
 from src.bot.services.user import UserService
-from src.bot.utils import delete_previous
+from src.bot.utils import delete_previous_message
 from src.core.logging.utils import logger_decor
 from src.settings import settings
 
@@ -27,7 +27,7 @@ log = structlog.get_logger()
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Возвращает в меню."""
     await context.bot.send_message(
@@ -38,7 +38,7 @@ async def menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def set_mailing(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Включение/выключение подписки пользователя на почтовую рассылку."""
     telegram_id = update.effective_user.id
@@ -121,7 +121,7 @@ async def web_app_data(update: Update):
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def about_project(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await context.bot.send_message(
         chat_id=update.effective_chat.id,

--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -5,7 +5,7 @@ from telegram.ext import Application, CallbackQueryHandler, CommandHandler, Cont
 from src.bot.constants import callback_data, commands
 from src.bot.keyboards import get_confirm_keyboard, get_start_keyboard
 from src.bot.services.user import UserService
-from src.bot.utils import delete_previous
+from src.bot.utils import delete_previous_message
 from src.core.logging.utils import logger_decor
 
 
@@ -35,7 +35,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def confirm_chosen_categories(update: Update, context: ContextTypes.DEFAULT_TYPE):
     keyboard = get_confirm_keyboard()
 

--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -5,6 +5,7 @@ from telegram.ext import Application, CallbackQueryHandler, CommandHandler, Cont
 from src.bot.constants import callback_data, commands
 from src.bot.keyboards import get_confirm_keyboard, get_start_keyboard
 from src.bot.services.user import UserService
+from src.bot.utils import delete_previous
 from src.core.logging.utils import logger_decor
 
 
@@ -34,6 +35,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 @logger_decor
+@delete_previous
 async def confirm_chosen_categories(update: Update, context: ContextTypes.DEFAULT_TYPE):
     keyboard = get_confirm_keyboard()
 

--- a/src/bot/handlers/tasks.py
+++ b/src/bot/handlers/tasks.py
@@ -11,6 +11,7 @@ from src.bot.keyboards import (
 )
 from src.bot.services.category import CategoryService
 from src.bot.services.task import TaskService
+from src.bot.utils import delete_previous
 from src.core.logging.utils import logger_decor
 from src.core.utils import display_tasks
 
@@ -70,6 +71,7 @@ async def back_subcategory_callback(update: Update, context: ContextTypes.DEFAUL
 
 
 @logger_decor
+@delete_previous
 async def view_task_callback(update: Update, context: CallbackContext, limit: int = 3):
     task_service = TaskService()
     tasks_to_show, offset, page_number = await task_service.get_user_tasks_by_page(
@@ -84,6 +86,7 @@ async def view_task_callback(update: Update, context: CallbackContext, limit: in
     await show_next_tasks(update, context, limit, offset, page_number)
 
 
+@delete_previous
 async def show_next_tasks(update: Update, context: CallbackContext, limit: int, offset: int, page_number: int):
     task_service = TaskService()
     remaining_tasks = await task_service.get_remaining_user_tasks_count(limit, offset)

--- a/src/bot/handlers/tasks.py
+++ b/src/bot/handlers/tasks.py
@@ -11,7 +11,7 @@ from src.bot.keyboards import (
 )
 from src.bot.services.category import CategoryService
 from src.bot.services.task import TaskService
-from src.bot.utils import delete_previous
+from src.bot.utils import delete_previous_message
 from src.core.logging.utils import logger_decor
 from src.core.utils import display_tasks
 
@@ -71,7 +71,7 @@ async def back_subcategory_callback(update: Update, context: ContextTypes.DEFAUL
 
 
 @logger_decor
-@delete_previous
+@delete_previous_message
 async def view_task_callback(update: Update, context: CallbackContext, limit: int = 3):
     task_service = TaskService()
     tasks_to_show, offset, page_number = await task_service.get_user_tasks_by_page(
@@ -86,7 +86,7 @@ async def view_task_callback(update: Update, context: CallbackContext, limit: in
     await show_next_tasks(update, context, limit, offset, page_number)
 
 
-@delete_previous
+@delete_previous_message
 async def show_next_tasks(update: Update, context: CallbackContext, limit: int, offset: int, page_number: int):
     task_service = TaskService()
     remaining_tasks = await task_service.get_remaining_user_tasks_count(limit, offset)

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -4,16 +4,23 @@ from typing import ParamSpec, TypeVar
 
 from telegram import Update
 
-T = TypeVar("T")
-P = ParamSpec("P")
+ReturnType = TypeVar("ReturnType")
+ParameterTypes = ParamSpec("ParameterTypes")
 
 
-def delete_previous(coroutine: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
-    """Для функций, отправляющих сообщения с inline-кнопками.
-    Удаляет сообщение с кнопками, приведшее к вызову функции."""
+def delete_previous(
+    coroutine: Callable[ParameterTypes, Awaitable[ReturnType]]
+) -> Callable[ParameterTypes, Awaitable[ReturnType]]:
+    """Декоратор для функций, отправляющих новые сообщения с inline-кнопками.
+    После выполнения оборачиваемой функции удаляет сообщение с inline-кнопкой,
+    нажатие на которую повлекло вызов оборачиваемой функции."""
 
     @wraps(coroutine)
-    async def wrapper(update: Update, *args: P.args, **kwargs: P.kwargs) -> T:
+    async def wrapper(
+        update: Update,
+        *args: ParameterTypes.args,
+        **kwargs: ParameterTypes.kwargs
+    ) -> ReturnType:
         result = await coroutine(update, *args, **kwargs)
         await update.callback_query.message.delete()
         return result

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -6,7 +6,7 @@ def delete_previous(coroutine):
     Удаляет сообщение с кнопками, приведшее к вызову функции."""
 
     async def wrapper(*args, **kwargs):
-        result = await coroutine(*args, **kwargs)
+        result = await coroutine(update: Update, *args, **kwargs)
         if "update" in kwargs and isinstance(kwargs["update"], Update):
             update = kwargs["update"]
         else:

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -8,7 +8,7 @@ ReturnType = TypeVar("ReturnType")
 ParameterTypes = ParamSpec("ParameterTypes")
 
 
-def delete_previous(
+def delete_previous_message(
     coroutine: Callable[ParameterTypes, Awaitable[ReturnType]]
 ) -> Callable[ParameterTypes, Awaitable[ReturnType]]:
     """Декоратор для функций, отправляющих новые сообщения с inline-кнопками.

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -7,8 +7,8 @@ def delete_previous(coroutine):
 
     async def wrapper(*args, **kwargs):
         result = await coroutine(*args, **kwargs)
-        if 'update' in kwargs and isinstance(kwargs['update'], Update):
-            update = kwargs['update']
+        if "update" in kwargs and isinstance(kwargs["update"], Update):
+            update = kwargs["update"]
         else:
             for arg in args:
                 if isinstance(arg, Update):
@@ -18,4 +18,5 @@ def delete_previous(coroutine):
                 return result  # если нет update, просто возвращаем результат работы
         await update.callback_query.message.delete()
         return result
+
     return wrapper

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -1,0 +1,21 @@
+from telegram import Update
+
+
+def delete_previous(coroutine):
+    """Для функций, отправляющих сообщения с inline-кнопками.
+    Удаляет сообщение с кнопками, приведшее к вызову функции."""
+
+    async def wrapper(*args, **kwargs):
+        result = await coroutine(*args, **kwargs)
+        if 'update' in kwargs and isinstance(kwargs['update'], Update):
+            update = kwargs['update']
+        else:
+            for arg in args:
+                if isinstance(arg, Update):
+                    update = arg
+                    break
+            else:
+                return result  # если нет update, просто возвращаем результат работы
+        await update.callback_query.message.delete()
+        return result
+    return wrapper

--- a/src/core/logging/utils.py
+++ b/src/core/logging/utils.py
@@ -4,8 +4,8 @@ from typing import ParamSpec, TypeVar
 
 import structlog
 
-T = TypeVar("T")
-P = ParamSpec("P")
+ReturnType = TypeVar("ReturnType")
+ParameterTypes = ParamSpec("ParameterTypes")
 
 log = structlog.get_logger()
 
@@ -18,10 +18,15 @@ async def logging_updates(*args, **kwargs):
     )
 
 
-def logger_decor(coroutine: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+def logger_decor(
+    coroutine: Callable[ParameterTypes, Awaitable[ReturnType]]
+) -> Callable[ParameterTypes, Awaitable[ReturnType]]:
     
     @wraps(coroutine)
-    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+    async def wrapper(
+        *args: ParameterTypes.args,
+        **kwargs: ParameterTypes.kwargs
+    ) -> ReturnType:
         await log.ainfo(
             f"Запущенна функция {coroutine.__name__}",
             args=args,

--- a/src/core/logging/utils.py
+++ b/src/core/logging/utils.py
@@ -1,16 +1,32 @@
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
 import structlog
 
-
-async def logging_updates(*args, **kwargs):
-    await log.ainfo("Следующие Updates не были пойманы ни одним из обработчиков", args=args, kwargs=kwargs)
-
+T = TypeVar("T")
+P = ParamSpec("P")
 
 log = structlog.get_logger()
 
 
-def logger_decor(func):
-    async def wrapper(*args, **kwargs):
-        await log.ainfo(f"Запущенна функция {func.__name__}", args=args, kwargs=kwargs)
-        return await func(*args, **kwargs)
+async def logging_updates(*args, **kwargs):
+    await log.ainfo(
+        "Следующие Updates не были пойманы ни одним из обработчиков",
+        args=args,
+        kwargs=kwargs
+    )
+
+
+def logger_decor(coroutine: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    
+    @wraps(coroutine)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        await log.ainfo(
+            f"Запущенна функция {coroutine.__name__}",
+            args=args,
+            kwargs=kwargs,
+        )
+        return await coroutine(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Тикет https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/issues/121

Реализовано удаление сообщений с кнопками при вызове хэндлеров этих кнопок.

Добавлен файл src.bot.utils.py, где добавлен декоратор для оборачивания функций, в которых реализуется отправка новых сообщений с инлайн-клавиатурами.

Для хэндлеров форм обратной связи декоратор пока не довлен, так как их работа не может быть завершена корректно.