### PR TITLE
Feature/save user category directly to db

### DIFF
--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -53,14 +53,14 @@ class UserService:
             await repository.set_categories_to_user(telegram_id, categories_ids)
 
     async def add_category_to_user(self, telegram_id: int, category_id: int) -> None:
-        """ Добавляет пользователю указанную категорию"""
+        """Добавляет пользователю указанную категорию"""
         async with self._sessionmaker() as session:
             repository = UserRepository(session)
             user = await repository.get_by_telegram_id(telegram_id)
             await repository.add_category_to_user(user, category_id)
 
     async def delete_category_from_user(self, telegram_id: int, category_id: int) -> None:
-        """ Удаляет у пользователя указанную категорию"""
+        """Удаляет у пользователя указанную категорию"""
         async with self._sessionmaker() as session:
             repository = UserRepository(session)
             user = await repository.get_by_telegram_id(telegram_id)

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -4,7 +4,7 @@ from typing import Generator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.db.db import get_session
-from src.core.db.models import User
+from src.core.db.models import User, UsersCategories
 from src.core.db.repository.user import UserRepository
 
 
@@ -57,7 +57,7 @@ class UserService:
         async with self._sessionmaker() as session:
             repository = UserRepository(session)
             user = await repository.get_by_telegram_id(telegram_id)
-            await repository.add_category_to_user(user, category_id)
+            await repository.create(UsersCategories(user_id=user.id, category_id=category_id))
 
     async def delete_category_from_user(self, telegram_id: int, category_id: int) -> None:
         """Удаляет у пользователя указанную категорию"""

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -58,7 +58,7 @@ class UserService:
             repository = UserRepository(session)
             user = await repository.get_by_telegram_id(telegram_id)
             await repository.add_category_to_user(user, category_id)
-    
+
     async def delete_category_from_user(self, telegram_id: int, category_id: int) -> None:
         """ Удаляет у пользователя указанную категорию"""
         async with self._sessionmaker() as session:

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -52,6 +52,20 @@ class UserService:
             repository = UserRepository(session)
             await repository.set_categories_to_user(telegram_id, categories_ids)
 
+    async def add_category_to_user(self, telegram_id: int, category_id: int) -> None:
+        """ Добавляет пользователю указанную категорию"""
+        async with self._sessionmaker() as session:
+            repository = UserRepository(session)
+            user = await repository.get_by_telegram_id(telegram_id)
+            await repository.add_category_to_user(user, category_id)
+    
+    async def delete_category_from_user(self, telegram_id: int, category_id: int) -> None:
+        """ Удаляет у пользователя указанную категорию"""
+        async with self._sessionmaker() as session:
+            repository = UserRepository(session)
+            user = await repository.get_by_telegram_id(telegram_id)
+            await repository.delete_category_from_user(user, category_id)
+
     async def get_user_categories(self, telegram_id: int) -> dict[int, str]:
         """Возвращает словарь с id и name категорий пользователя по его telegram_id."""
         async with self._sessionmaker() as session:

--- a/src/core/db/repository/base.py
+++ b/src/core/db/repository/base.py
@@ -41,6 +41,11 @@ class AbstractRepository(abc.ABC):
         await self._session.refresh(instance)
         return instance
 
+    async def remove(self, instance: DatabaseModel) -> None:
+        """Удаляет объект модели из базы данных."""
+        await self._session.delete(instance)
+        await self._session.commit()
+
     @auto_commit
     async def update(self, _id: int, instance: DatabaseModel) -> DatabaseModel:
         """Обновляет существующий объект модели в базе."""

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -47,7 +47,7 @@ class UserRepository(AbstractRepository):
     async def add_category_to_user(self, user: User, category_id: int) -> None:
         """Добавляет категорию для пользователя."""
         await self.create(UsersCategories(user_id=user.id, category_id=category_id))
-    
+
     async def delete_category_from_user(self, user: User, category_id: int) -> None:
         """Удаляет категорию у пользователя."""
         users_categories_obj = await self._session.scalar(

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -2,7 +2,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from src.core.db.models import Category, User
+from src.core.db.models import Category, User, UsersCategories
 from src.core.db.repository.base import AbstractRepository
 
 
@@ -43,6 +43,19 @@ class UserRepository(AbstractRepository):
         user.categories = categories
         if user:
             await self.update(user.id, user)
+
+    async def add_category_to_user(self, user: User, category_id: int) -> None:
+        """Добавляет категорию для пользователя."""
+        await self.create(UsersCategories(user_id=user.id, category_id=category_id))
+    
+    async def delete_category_from_user(self, user: User, category_id: int) -> None:
+        """Удаляет категорию у пользователя."""
+        users_categories_obj = await self._session.scalar(
+            select(UsersCategories)
+            .where(UsersCategories.user_id == user.id)
+            .where(UsersCategories.category_id == category_id)
+        )
+        await self.remove(users_categories_obj)
 
     async def get_user_categories(self, user: User) -> list[Category]:
         """Возвращает список категорий пользователя."""


### PR DESCRIPTION
**Что изменилось:**
Заменил context для сохранения/выгрузки выбранных категорий на UserRepository через UserService соответственно.
Добавил методы для сохранения/удаления выбранных пользователем категорий в процессе их изменения.
Кнопка "готово" теперь не сохраняет категории пользователя в БД, а только передает их дальше, в следующую функцию.

**Как тестировал:**
Добавлял/удалял категории пользователя в боте, и проверял в DBeaver что они сразу же обновляются в БД.  

**Костыли:**
Была проблемка с реализацией удаления категории в ``UserRepository.delete_category_from_user`` - не получалось реализовать удаление без предварительного доставания объекта из БД. Не уверен, возможно ли улучшить? (убрать предварительное доставание объекта из БД)
У меня выдавало ошибку мол такого объекта в БД нет (удалять нечего).
