### PR TITLE
Revert "added commit info to workflow"

### DIFF
--- a/.github/workflows/deploy_stage.yaml
+++ b/.github/workflows/deploy_stage.yaml
@@ -103,9 +103,6 @@ jobs:
             MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}
             ORGANIZATIONS_EMAIL=${{ secrets.ORGANIZATIONS_EMAIL }}
             EMAIL_ADMIN=${{ secrets.EMAIL_ADMIN }}
-            LAST_COMMIT=${{ github.workflow_sha }}
-            COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y%m%dh%H%M%S)
-            TAGS=${{ github.workflow_ref }}
             EOM
   start_application:
     name: Start application


### PR DESCRIPTION
Server fall with the value error because of incorrect env file. 

These are the new values in the env file on the server:

```
LAST_COMMIT=952a7a9593305f07d067a234b8037675f9a85860
COMMIT_DATE=
TAGS=Studio-Yandex-Practicum/ProCharity_back_2.0/.github/workflows/deploy_stage.yaml@refs/heads/develop
```

As you can see, the `COMMIT_DATE` is empty and the `TAGS` are incorrect. 