### PR TITLE
delete get_unarchived_parents

### DIFF
--- a/src/bot/services/category.py
+++ b/src/bot/services/category.py
@@ -8,9 +8,6 @@ class CategoryService:
     def __init__(self, category_repository: CategoryRepository) -> None:
         self._category_repository = category_repository
 
-    async def get_unarchived_parents(self) -> list[Category]:
-        return await self._category_repository.get_unarchived_parents()
-
     async def get_unarchived_subcategories(self, parent_id) -> list[Category]:
         return await self._category_repository.get_unarchived_subcategories(parent_id)
 

--- a/src/core/db/repository/category.py
+++ b/src/core/db/repository/category.py
@@ -11,17 +11,10 @@ class CategoryRepository(ContentRepository):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session, Category)
 
-    async def get_unarchived_parents(self) -> list[Category]:
-        categories = await self._session.scalars(
-            select(Category).where(Category.is_archived == false()).where(Category.parent_id == null())
-        )
-        return categories
-
     async def get_unarchived_subcategories(self, parent_id: int) -> list[Category]:
-        categories = await self._session.scalars(
+        return await self._session.scalars(
             select(Category).where(Category.is_archived == false()).where(Category.parent_id == parent_id)
         )
-        return categories
 
     async def get_unarchived_parents_with_children_count(self):
         parent_and_children_count_subquery = (


### PR DESCRIPTION
[#239](https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/issues/239)

Удалена нигде неиспользуемая функция `get_unarchived_parents`
- В классе `CategoryService`
- В классе `CategoryRepository`