### PR TITLE
Исправлен ендпоинт /external_user_registration/

### DIFF
--- a/src/api/endpoints/external_site_user.py
+++ b/src/api/endpoints/external_site_user.py
@@ -9,7 +9,7 @@ from src.depends import Container
 site_user_router = APIRouter(dependencies=[Depends(check_header_contains_token)])
 
 
-@site_user_router.post("/", description="Актуализирует пользователя с сайта ProCharity.")
+@site_user_router.post("/external_user_registration/", description="Актуализирует пользователя с сайта ProCharity.")
 @inject
 async def external_user_registration(
     site_user: ExternalSiteUserRequest,

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -17,7 +17,7 @@ api_router.include_router(analytic_router, prefix="/analytics", tags=["Analytic"
 api_router.include_router(category_router, prefix="/categories", tags=["Content"])
 api_router.include_router(health_check_router, prefix="/health_check", tags=["Healthcheck"])
 api_router.include_router(notification_router, prefix="/messages", tags=["Messages"])
-api_router.include_router(site_user_router, prefix="/auth/external_user_registration", tags=["ExternalSiteUser"])
 api_router.include_router(task_router, prefix="/tasks", tags=["Content"])
 api_router.include_router(telegram_webhook_router, prefix="/telegram", tags=["Telegram"])
 api_router.include_router(admin_user_router, prefix="/auth", tags=["AdminUser"])
+api_router.include_router(site_user_router, prefix="/auth", tags=["ExternalSiteUser"])

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -17,7 +17,7 @@ api_router.include_router(analytic_router, prefix="/analytics", tags=["Analytic"
 api_router.include_router(category_router, prefix="/categories", tags=["Content"])
 api_router.include_router(health_check_router, prefix="/health_check", tags=["Healthcheck"])
 api_router.include_router(notification_router, prefix="/messages", tags=["Messages"])
-api_router.include_router(site_user_router, prefix="/external_user_registration", tags=["ExternalSiteUser"])
+api_router.include_router(site_user_router, prefix="/auth/external_user_registration", tags=["ExternalSiteUser"])
 api_router.include_router(task_router, prefix="/tasks", tags=["Content"])
 api_router.include_router(telegram_webhook_router, prefix="/telegram", tags=["Telegram"])
 api_router.include_router(admin_user_router, prefix="/auth", tags=["AdminUser"])


### PR DESCRIPTION
### До исправления:
![До правок](https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/assets/96495051/7ab72ace-331d-4baa-9549-17b7d7f0ee47)

### После исправления:
![После правок](https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/assets/96495051/49cbaab4-a53d-40d6-bc7d-affdebed4e84)

### Что сделано:
Эндпоинт `/api/external_user_registration/` изменен на `/api/auth/external_user_registration/`.

### Внесенные изменения:
* **`src/api/routers.py`**
При включении роутера `site_user_router` изменил префикс с `/external_user_registration` на `/auth`.

* **`src/api/endpoints/external_site_user.py`**
В декораторе создания `post`-запроса поменял путь с `/` на `/external_user_registration/`.

### Тестирование:
Проверено, что результаты отправки запросов к данному эндпоинту не поменялись после внесения изменений.