### PR TITLE
Исправлено дублирование эндпойнтов login и logout

### DIFF
--- a/src/api/endpoints/admin.py
+++ b/src/api/endpoints/admin.py
@@ -10,6 +10,5 @@ admin_user_router.include_router(fastapi_users.get_auth_router(auth_backend))
 admin_user_router.include_router(fastapi_users.get_register_router(UserRead, UserCreate))
 admin_user_router.include_router(
     fastapi_users.get_auth_router(auth_cookie_backend),
-    prefix="/auth/cookies",
-    tags=["Admin Login Logout By Cookies"],
+    prefix="/cookies",
 )


### PR DESCRIPTION
### Что сделано
1. В src/api/endpoints/admin.py
- убрано дублирование /auth в URL эндпойнтов;
- убран тег 'Admin Login Logout By Cookies', который приводил к появлению дополнительного раздела в документации API с дублированием эндпойнтов.

### Как проверял
Отправлял запросы к эндпойнтам через документацию API.
Так как зарегистрированного пользователя в БД у меня нет, то в login посылал произвольные логин и пароль, получал в ответ ошибку 400 {"detail": "LOGIN_BAD_CREDENTIALS"}.
При обращении к logout получал ошибку 401 {"detail": "Unauthorized"}.
Думаю, этого достаточно, чтобы убедится, что эндпойнты никуда не пропали и доступны по новым URL, а их логику я не менял.