### PR TITLE
Feature/user id to id hash

### DIFF
--- a/src/api/endpoints/notification.py
+++ b/src/api/endpoints/notification.py
@@ -44,7 +44,7 @@ async def send_messages_to_group_of_users(
     await log.ainfo("Начало отправки сообщений для группы пользователей")
     rate = InfoRate()
     for message in message_list.messages:
-        status, msg = await telegram_notification_service.send_message_to_user(message.user_id, message.message)
+        status, msg = await telegram_notification_service.send_message_to_user(message.id_hash, message.message)
         rate = telegram_notification_service.count_rate(status, msg, rate)
     await log.ainfo("Конец отправки сообщений для группы пользователей")
     return rate

--- a/src/api/schemas/notification.py
+++ b/src/api/schemas/notification.py
@@ -34,7 +34,7 @@ class TelegramNotificationUsersRequest(TelegramNotificationRequest):
 
 
 class Message(TelegramNotificationRequest):
-    user_id: int
+    id_hash: str
 
 
 class MessageList(RequestBase):

--- a/src/api/services/messages.py
+++ b/src/api/services/messages.py
@@ -32,9 +32,9 @@ class TelegramNotificationService:
                 users = await self._session.scalars(select(User).where(User.has_mailing == False))  # noqa
         return await self.telegram_notification.send_messages(message=notifications.message, users=users)
 
-    async def send_message_to_user(self, user_id: int, message: str) -> tuple[bool, str]:
+    async def send_message_to_user(self, id_hash: str, message: str) -> tuple[bool, str]:
         """Отправляет сообщение указанному по telegram_id пользователю"""
-        site_user = await self._session.scalar(select(ExternalSiteUser).where(ExternalSiteUser.external_id == user_id))
+        site_user = await self._session.scalar(select(ExternalSiteUser).where(ExternalSiteUser.id_hash == id_hash))
         if site_user is None:
             return False, "Пользователя не найден."
         if site_user.user is None:


### PR DESCRIPTION
**Что сделано:**
Поправлен эндпоинт отправки сообщений `/messages/group`: - `user_id` (id пользователя на сайте) заменен на `id_hash` (хеш `user_id`).
Метод `get_by_id_hash` в репозитории присутствует.
Заменена схема запроса на /messages/group, вместо `user_id: int` теперь `id_hash: str`.

**Как тестировал:**
Дергал за ручку /api/messages/group через docs с указанием  `id_hash: str` уже вместо `user_id: int`, в ответ возвращался статус 200.
