### PR TITLE
Fix/start_command keyboard and message

### DIFF
--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -6,7 +6,7 @@ from telegram.constants import ParseMode
 from telegram.ext import Application, ChatMemberHandler, CommandHandler, ContextTypes
 
 from src.bot.constants import commands
-from src.bot.keyboards import get_open_menu_keyboard, get_start_keyboard
+from src.bot.keyboards import get_start_menu_keyboard
 from src.bot.services import UserService
 from src.bot.utils import registered_user_required
 from src.core.db.models import ExternalSiteUser
@@ -28,13 +28,7 @@ async def start_command(
 ):
     telegram_user = update.effective_user or Never
     user = await user_service.register_user(ext_site_user, telegram_user)
-
-    if user.role == UserRoles.VOLUNTEER:
-        keyboard = await get_start_keyboard()
-        auth_url = volunteer_auth_url
-    else:
-        keyboard = await get_open_menu_keyboard()
-        auth_url = found_auth_url
+    auth_url = volunteer_auth_url if user.role == UserRoles.VOLUNTEER else found_auth_url
 
     await context.bot.send_message(
         chat_id=telegram_user.id,
@@ -43,7 +37,7 @@ async def start_command(
         f'Изменить настройку уведомлений можно в <a href="{auth_url}">личном кабинете</a>.\n\n'
         "Навигация по боту запускается командой /menu.",
         parse_mode=ParseMode.HTML,
-        reply_markup=keyboard,
+        reply_markup=await get_start_menu_keyboard(user.role),
         disable_web_page_preview=True,
     )
 

--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -6,7 +6,7 @@ from telegram.constants import ParseMode
 from telegram.ext import Application, ChatMemberHandler, CommandHandler, ContextTypes
 
 from src.bot.constants import commands
-from src.bot.keyboards import get_start_menu_keyboard
+from src.bot.keyboards import get_start_keyboard
 from src.bot.services import UserService
 from src.bot.utils import registered_user_required
 from src.core.db.models import ExternalSiteUser
@@ -24,11 +24,11 @@ async def start_command(
     ext_site_user: ExternalSiteUser,
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
     volunteer_auth_url: str = Provide[Container.settings.provided.procharity_volunteer_auth_url],
-    found_auth_url: str = Provide[Container.settings.provided.procharity_found_auth_url],
+    fund_auth_url: str = Provide[Container.settings.provided.procharity_fund_auth_url],
 ):
     telegram_user = update.effective_user or Never
     user = await user_service.register_user(ext_site_user, telegram_user)
-    auth_url = volunteer_auth_url if user.role == UserRoles.VOLUNTEER else found_auth_url
+    auth_url = volunteer_auth_url if user.role == UserRoles.VOLUNTEER else fund_auth_url
 
     await context.bot.send_message(
         chat_id=telegram_user.id,
@@ -37,7 +37,7 @@ async def start_command(
         f'Изменить настройку уведомлений можно в <a href="{auth_url}">личном кабинете</a>.\n\n'
         "Навигация по боту запускается командой /menu.",
         parse_mode=ParseMode.HTML,
-        reply_markup=await get_start_menu_keyboard(user.role),
+        reply_markup=await get_start_keyboard(user.role),
         disable_web_page_preview=True,
     )
 

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -6,7 +6,6 @@ from src.bot.web_apps import get_feedback_web_app_info, get_task_web_app_info
 from src.core.db.models import Category, Task, User
 from src.core.depends import Container
 from src.core.enums import UserRoles
-from src.settings import settings
 
 VIEW_TASKS_BUTTON = [InlineKeyboardButton("🔎 Посмотреть актуальные задания", callback_data=callback_data.VIEW_TASKS)]
 VIEW_CURRENT_TASKS_BUTTON = [

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -7,6 +7,7 @@ from src.api.schemas import FeedbackFormQueryParams
 from src.bot.constants import callback_data, enum
 from src.core.db.models import Category, Task, User
 from src.core.depends import Container
+from src.core.enums import UserRoles
 from src.settings import settings
 
 VIEW_TASKS_BUTTON = [InlineKeyboardButton("🔎 Посмотреть актуальные задания", callback_data=callback_data.VIEW_TASKS)]
@@ -127,13 +128,6 @@ def get_feedback_web_app_info(user: User) -> WebAppInfo:
     )
 
 
-async def get_open_menu_keyboard() -> InlineKeyboardMarkup:
-    keyboard = [
-        OPEN_MENU_BUTTON,
-    ]
-    return InlineKeyboardMarkup(keyboard)
-
-
 async def get_back_menu() -> InlineKeyboardMarkup:
     keyboard = [
         RETURN_MENU_BUTTON,
@@ -141,9 +135,9 @@ async def get_back_menu() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(keyboard)
 
 
-async def get_start_keyboard() -> InlineKeyboardMarkup:
+async def get_start_menu_keyboard(user_role: str) -> InlineKeyboardMarkup:
     keyboard = [
-        CHECK_CATEGORIES_BUTTON,
+        CHECK_CATEGORIES_BUTTON if user_role == UserRoles.VOLUNTEER else [],
         OPEN_MENU_BUTTON,
     ]
     return InlineKeyboardMarkup(keyboard)

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -135,7 +135,7 @@ async def get_back_menu() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(keyboard)
 
 
-async def get_start_menu_keyboard(user_role: str) -> InlineKeyboardMarkup:
+async def get_start_keyboard(user_role: str) -> InlineKeyboardMarkup:
     keyboard = [
         CHECK_CATEGORIES_BUTTON if user_role == UserRoles.VOLUNTEER else [],
         OPEN_MENU_BUTTON,

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -127,6 +127,13 @@ def get_feedback_web_app_info(user: User) -> WebAppInfo:
     )
 
 
+async def get_open_menu_keyboard() -> InlineKeyboardMarkup:
+    keyboard = [
+        OPEN_MENU_BUTTON,
+    ]
+    return InlineKeyboardMarkup(keyboard)
+
+
 async def get_back_menu() -> InlineKeyboardMarkup:
     keyboard = [
         RETURN_MENU_BUTTON,

--- a/src/settings.py
+++ b/src/settings.py
@@ -156,7 +156,7 @@ class Settings(BaseSettings):
         return urljoin(self.PROCHARITY_URL, "volunteers/settings/")
 
     @property
-    def procharity_found_auth_url(self) -> str:
+    def procharity_fund_auth_url(self) -> str:
         """Получить url-ссылку на страницу авторизации фонда."""
         return urljoin(self.PROCHARITY_URL, "foundations/lk/settings/")
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -156,6 +156,11 @@ class Settings(BaseSettings):
         return urljoin(self.PROCHARITY_URL, "volunteers/settings/")
 
     @property
+    def procharity_found_auth_url(self) -> str:
+        """Получить url-ссылку на страницу авторизации фонда."""
+        return urljoin(self.PROCHARITY_URL, "foundations/lk/settings/")
+
+    @property
     def procharity_faq_volunteer_url(self) -> str:
         """Получить url-ссылку на страницу базы знаний."""
         return urljoin(self.HELP_PROCHARITY_URL, "category/1876")


### PR DESCRIPTION
### Что сделано
Поправил поведение команды `Старт` в зависимости от роли пользователя, поменял ссылку на ЛК и кнопки.
Теперь функция `get_start_menu_keyboard` отображает кнопки в зависимости от роли.
В настройках добавлено свойство с ссылкой на ЛК фондов.
### Как проверял
Проверил отображение в боте под разными ролями.