### PR TITLE
Проверка роли пользователя при авторизации

### DIFF
--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -58,8 +58,7 @@ class UserService:
                 role=ext_site_user.role,
             )
             await logger.ainfo(f"Обновлены данные пользователя {user=}")
-            if ext_site_user.specializations:
-                await self.set_categories_to_user(user.id, ext_site_user.specializations)
+            await self.set_categories_to_user(user.id, ext_site_user.specializations)
 
         return user
 


### PR DESCRIPTION
### Что сделано
1. В декоратор `registered_user_required` добавлена проверка значения в поле `role `у `ext_site_user`. Если оно не является одним из допустимых (волонтёр или фонд), то пользователь считается неавторизованным и ему выводится сообщение о необходимости регистрации.
2. Исправлена политика при обновлении категорий при смене ЛК. Если в новом ЛК нет категорий, то категории у пользователя обнуляются.
3. По п.3 задачи #484 все данные обновляются. Ничего делать не надо.

### Как проверял
Проверял локально.
Создал в БД в таблице `external_site_user` несколько записей с различными значениями `role`, в том числе неверными, и различными списками категорий, в том числе NULL. Затем переключался в боте между этими записями командой `/start id_hash` и проверял правильность проверки авторизации и обновления данных.

### Замечания
1. Обратил внимание на вот какую вещь. Эндпойнты из категории ExternalSiteUser позволяют обнулить значения  `first_name`, `last_name`, заданные ранее, если исключить соответствующие поля из запроса. По-моему это неправильно, обновление не должно так работать.
2. См. мой комментарий к задаче.