### PR TITLE
Добавление проверки авторизации пользователя в обработчики событий бота.

### DIFF
--- a/src/bot/handlers/categories.py
+++ b/src/bot/handlers/categories.py
@@ -12,17 +12,20 @@ from src.bot.keyboards import (
 )
 from src.bot.services.category import CategoryService
 from src.bot.services.user import UserService
-from src.bot.utils import delete_previous_message, get_marked_list
+from src.bot.utils import delete_previous_message, get_marked_list, registered_user_required
+from src.core.db.models import ExternalSiteUser
 from src.core.depends import Container
 from src.core.logging.utils import logger_decor
 from src.core.services.procharity_api import ProcharityAPI
 
 
 @logger_decor
+@registered_user_required
 @delete_previous_message
 async def categories_callback(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     category_service: CategoryService = Provide[Container.bot_services_container.bot_category_service],
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
 ):
@@ -66,7 +69,10 @@ async def view_categories(
             await user_service.check_and_set_has_mailing_atribute(telegram_id)
 
 
-async def view_current_categories_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+@registered_user_required
+async def view_current_categories_callback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, ext_site_user: ExternalSiteUser
+):
     """Выводит список выбранных волонтером категорий перед их изменением."""
     text_format = "*Твои профессиональные компетенции:*\n\n" "{categories}\n\n"
     await view_categories(
@@ -76,7 +82,10 @@ async def view_current_categories_callback(update: Update, context: ContextTypes
     )
 
 
-async def confirm_categories_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+@registered_user_required
+async def confirm_categories_callback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, ext_site_user: ExternalSiteUser
+):
     """Выводит список выбранных волонтером категорий после их изменения и включает рассылку (если еще не включена)."""
     text_format = (
         "*Отлично!*\n\n"
@@ -93,9 +102,11 @@ async def confirm_categories_callback(update: Update, context: ContextTypes.DEFA
 
 
 @logger_decor
+@registered_user_required
 async def subcategories_callback(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     category_service: CategoryService = Provide[Container.bot_services_container.bot_category_service],
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
 ):
@@ -114,9 +125,11 @@ async def subcategories_callback(
 
 
 @logger_decor
+@registered_user_required
 async def select_subcategory_callback(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     category_service: CategoryService = Provide[Container.bot_services_container.bot_category_service],
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
     procharity_api: ProcharityAPI = Provide[Container.core_services_container.procharity_api],
@@ -147,9 +160,11 @@ async def select_subcategory_callback(
 
 
 @logger_decor
+@registered_user_required
 async def back_subcategory_callback(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     category_service: CategoryService = Provide[Container.bot_services_container.bot_category_service],
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
 ):

--- a/src/bot/handlers/menu.py
+++ b/src/bot/handlers/menu.py
@@ -45,10 +45,12 @@ async def menu_callback(
 
 
 @logger_decor
+@registered_user_required
 @delete_previous_message
 async def set_mailing(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],
     procharity_tasks_url: str = Provide[Container.settings.provided.procharity_tasks_url],
 ):
@@ -79,9 +81,11 @@ async def set_mailing(
 
 
 @logger_decor
+@registered_user_required
 async def unsubscription_reason_handler(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     unsubscribe_reason_service: UnsubscribeReasonService = Provide[
         Container.bot_services_container.unsubscribe_reason_service
     ],
@@ -114,10 +118,12 @@ async def unsubscription_reason_handler(
 
 
 @logger_decor
+@registered_user_required
 @delete_previous_message
 async def support_service_callback(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
     volunteer_faq_url: str = Provide[Container.settings.provided.procharity_volunteer_faq_url],
     fund_faq_url: str = Provide[Container.settings.provided.procharity_fund_faq_url],
     user_service: UserService = Provide[Container.bot_services_container.bot_user_service],

--- a/src/bot/handlers/tasks.py
+++ b/src/bot/handlers/tasks.py
@@ -6,17 +6,20 @@ from telegram.ext import Application, CallbackContext, CallbackQueryHandler
 from src.bot.constants import callback_data
 from src.bot.keyboards import get_back_menu, get_task_info_keyboard, view_more_tasks_keyboard
 from src.bot.services.task import TaskService
-from src.bot.utils import delete_previous_message
+from src.bot.utils import delete_previous_message, registered_user_required
+from src.core.db.models import ExternalSiteUser
 from src.core.depends import Container
 from src.core.logging.utils import logger_decor
 from src.core.messages import display_task
 
 
 @logger_decor
+@registered_user_required
 @delete_previous_message
 async def view_task_callback(
     update: Update,
     context: CallbackContext,
+    ext_site_user: ExternalSiteUser,
     limit: int = 3,
     task_service: TaskService = Provide[Container.bot_services_container.bot_task_service],
 ):


### PR DESCRIPTION
### Что сделано
Декоратор `registered_user_required` применён во всех обработчиках событий бота, кроме `on_chat_member_update` из `registration.py` (по-моему, этот обработчик от авторизации не должен зависеть).

### Как проверял
Зашёл в бот через `/start id_hash`, проверил что все функции доступны.
Затем доходил по интерфейсу до какого-либо сообщения с инлайн-кнопками. Из другой учётки Телеграм (на другом устройстве) входил под тем же `id_hash`. Нажимал на первом устройстве инлайн-кнопки и убеждался, что их функции недоступны и выводится сообщение с предложением авторизоваться.
И так по всем сообщениям.

_Примечание_.  Кнопки с веб-апами и гиперссылками, конечно, оставались работающими. Их так не отключишь, потому что они заряжены ещё в момент их создания.