### PR TITLE
fix/toggle_mailing

### DIFF
--- a/src/bot/handlers/menu.py
+++ b/src/bot/handlers/menu.py
@@ -60,7 +60,7 @@ async def set_mailing(
     telegram_id = update.effective_user.id
     user = await user_service.get_by_telegram_id(telegram_id)
     if not user.has_mailing:
-        await user_service.toggle_mailing(telegram_id)
+        await user_service.toggle_mailing(user)
         text = "*Подписка включена!*\n\nТеперь ты будешь получать новые задания от фондов по выбранным компетенциям."
         keyboard = await get_tasks_and_back_menu_keyboard()
         parse_mode = ParseMode.MARKDOWN
@@ -101,7 +101,7 @@ async def unsubscription_reason_handler(
     """Выключение подписки пользователя и отправка сообщения с причиной на почту."""
     telegram_id = update.effective_user.id
     user = await user_service.get_by_telegram_id(telegram_id)
-    await user_service.toggle_mailing(telegram_id)
+    await user_service.toggle_mailing(user)
     query = update.callback_query
     reason = enum.REASONS[context.match.group(1)]
     await unsubscribe_reason_service.save_reason(telegram_id=context._user_id, reason=reason.name)

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -114,12 +114,11 @@ class UserService(BaseUserService):
         user = await self._user_repository.get_by_telegram_id(telegram_id)
         return user.has_mailing
 
-    async def toggle_mailing(self, telegram_id: int) -> bool:
+    async def toggle_mailing(self, user: User) -> bool:
         """
         Переключает пользователю флаг получения почтовой рассылки на задания.
         Возвращает статус подписки пользователя на почтовую рассылку.
         """
-        user = await self._user_repository.get_by_telegram_id(telegram_id)
         await self._user_repository.set_mailing(user, not user.has_mailing)
         return user.has_mailing
 


### PR DESCRIPTION
### Что сделано
- `src\bot\services\user.py`: в классе `UserSevice` изменил метод `toggle_mailing`, теперь он принимает параметр `user` вместо `telegram_id`, лишний код убрал.

- `src\bot\handlers\menu.py`: в `set_mailing` и `unsubscription_reason_handler` так же поправил `toggle_mailing`.

### Как проверял
Локально проверил в боте возможность подписаться/отписаться от рассылки.