### PR TITLE
Исправление ошибки в эндпойнте health_check

### DIFF
--- a/src/api/schemas/health_check.py
+++ b/src/api/schemas/health_check.py
@@ -33,6 +33,6 @@ class CommitStatus(TypedDict):
 class HealthCheck(ResponseBase):
     """Класс модели запроса для проверки работы бота."""
 
-    db: DBStatus = {}
-    bot: BotStatus = {}
-    git: CommitStatus = {}
+    db: DBStatus
+    bot: BotStatus
+    git: CommitStatus

--- a/src/api/services/health_check.py
+++ b/src/api/services/health_check.py
@@ -44,7 +44,7 @@ class HealthCheckService:
             commit_status: CommitStatus = {
                 "last_commit": str(master.commit)[:7],
                 "commit_date": commit_date.strftime(DATE_TIME_FORMAT),
-                "git_tags": repo.tags,
+                "git_tags": [str(tag) for tag in repo.tags],
             }
             return commit_status
         except (ImportError, NameError, TypeError) as exc:


### PR DESCRIPTION
### Что сделано
1. Устранена ошибка, возникающая при обращении к эндпойнту. Причина ошибки в том, что `repo.tags` - массив из `TagReference`, а ожидается массив строк, как, собственно, и указано в сообщении об ошибке. Преобразовал в строку и ошибка ушла.
2. Устранил заодно неуместные (и некорректные, кстати) значения по умолчанию для полей схемы `HealthCheck` - там все поля обязательные. Из-за них также формировался бестолковый пример ответа.

### Как проверял
Локально.
Обращался к эндпойнту через страницу документации API (с запущенной БД и без неё) - всё работает. Как сломать бот, не придумал - если задать неверный токен в `.env`, то программа просто не запускается.