### PR TITLE
fix_name_endpoint

### DIFF
--- a/src/api/router.py
+++ b/src/api/router.py
@@ -22,7 +22,7 @@ api_router.include_router(category_router, prefix="/categories", tags=["Content"
 api_router.include_router(health_check_router, prefix="/health_check", tags=["Healthcheck"])
 api_router.include_router(notification_router, prefix="/messages", tags=["Messages"])
 api_router.include_router(task_router, prefix="/tasks", tags=["Content"])
-api_router.include_router(task_detail_router, prefix="/tasks_detail", tags=["Content"])
+api_router.include_router(task_detail_router, prefix="/task", tags=["Content"])
 api_router.include_router(telegram_webhook_router, prefix="/telegram", tags=["Telegram"])
 api_router.include_router(admin_user_router, prefix="/auth", tags=["AdminUser"])
 api_router.include_router(site_user_router, prefix="/auth", tags=["ExternalSiteUser"])


### PR DESCRIPTION
В файле по адресу ProCharity_back_2.0\src\api\router.py в строке api_router.include_router(task_detail_router, prefix="/task", tags=["Content"]) поменял prefix с tasks_detail на task. Отправил запрос и получил статус 200 и детали таска.