### PR TITLE
fix/url_path_for_pagination

### DIFF
--- a/src/api/endpoints/users.py
+++ b/src/api/endpoints/users.py
@@ -1,5 +1,5 @@
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from src.api.fastapi_admin_users import fastapi_admin_users
 from src.api.pagination import UserPaginator
@@ -23,13 +23,14 @@ user_router = APIRouter(
 )
 @inject
 async def get_all_users(
+    request: Request,
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=20, ge=1),
     user_service: UserService = Depends(Provide[Container.api_services_container.user_service]),
     user_paginate: UserPaginator = Depends(Provide[Container.api_paginate_container.user_paginate]),
 ) -> UsersPaginatedResponse:
     users = await user_service.get_users_by_page(page, limit)
-    return await user_paginate.paginate(users, page, limit, user_router.url_path_for("get_all_users"))
+    return await user_paginate.paginate(users, page, limit, request.url_for("get_all_users"))
 
 
 @user_router.get(

--- a/src/api/endpoints/users.py
+++ b/src/api/endpoints/users.py
@@ -29,7 +29,7 @@ async def get_all_users(
     user_paginate: UserPaginator = Depends(Provide[Container.api_paginate_container.user_paginate]),
 ) -> UsersPaginatedResponse:
     users = await user_service.get_users_by_page(page, limit)
-    return await user_paginate.paginate(users, page, limit, settings.users_url)
+    return await user_paginate.paginate(users, page, limit, user_router.url_path_for("get_all_users"))
 
 
 @user_router.get(

--- a/src/api/endpoints/users.py
+++ b/src/api/endpoints/users.py
@@ -30,7 +30,7 @@ async def get_all_users(
     user_paginate: UserPaginator = Depends(Provide[Container.api_paginate_container.user_paginate]),
 ) -> UsersPaginatedResponse:
     users = await user_service.get_users_by_page(page, limit)
-    return await user_paginate.paginate(users, page, limit, request.url_for("get_all_users"))
+    return await user_paginate.paginate(users, page, limit, request.url.path)
 
 
 @user_router.get(

--- a/src/settings.py
+++ b/src/settings.py
@@ -144,11 +144,6 @@ class Settings(BaseSettings):
         return urljoin(self.api_url, "telegram/webhook")
 
     @property
-    def users_url(self) -> str:
-        """Получить url-ссылку на эндпоинт Users."""
-        return urljoin(self.ROOT_PATH + "/", "users")
-
-    @property
     def feedback_form_template_url(self) -> str:
         """Получить url-ссылку на HTML шаблон формы обратной связи."""
         return urljoin(self.static_url, "feedback_form/feedback_form.html")


### PR DESCRIPTION
### Что сделано
`src\api\endpoints\users.py`:
Поменял способ формирования `url` для пагинации, теперь он создаётся с использованием метода `url_path_for`.
### Как проверял
Локально проверил работоспособность эндпоита `api/users/` в админке.