### PR TITLE
Fix faulty transaction behaviour in set_categories_to_user

### DIFF
--- a/src/core/db/repository/base.py
+++ b/src/core/db/repository/base.py
@@ -41,8 +41,6 @@ class AbstractRepository(abc.ABC, Generic[DatabaseModel]):
             await self._session.commit()
         except DuplicateColumnError as exc:
             raise AlreadyExistsException(instance) from exc
-
-        await self._session.refresh(instance)
         return instance
 
     async def remove(self, instance: DatabaseModel) -> None:

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -64,7 +64,7 @@ class UserRepository(AbstractRepository):
 
     async def set_categories_to_user(self, user_id: int, categories_ids: list[int] | None) -> None:
         """Присваивает или удаляет список категорий."""
-        async with self._session.begin_nested():
+        async with self._session.begin():
             await self._session.execute(delete(UsersCategories).where(UsersCategories.user_id == user_id))
             if categories_ids:
                 await self._session.execute(

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -64,11 +64,10 @@ class UserRepository(AbstractRepository):
 
     async def set_categories_to_user(self, user_id: int, categories_ids: list[int] | None) -> None:
         """Присваивает или удаляет список категорий."""
-        await self._session.commit()
-        async with self._session.begin():
-            await self._session.execute(delete(UsersCategories).where(UsersCategories.user_id == user_id))
+        async with self._session as session:
+            await session.execute(delete(UsersCategories).where(UsersCategories.user_id == user_id))
             if categories_ids:
-                await self._session.execute(
+                await session.execute(
                     insert(UsersCategories).values(
                         [{"user_id": user_id, "category_id": category_id} for category_id in categories_ids]
                     )

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -64,10 +64,10 @@ class UserRepository(AbstractRepository):
 
     async def set_categories_to_user(self, user_id: int, categories_ids: list[int] | None) -> None:
         """Присваивает или удаляет список категорий."""
-        async with self._session as session:
-            await session.execute(delete(UsersCategories).where(UsersCategories.user_id == user_id))
+        async with self._session.begin_nested():
+            await self._session.execute(delete(UsersCategories).where(UsersCategories.user_id == user_id))
             if categories_ids:
-                await session.execute(
+                await self._session.execute(
                     insert(UsersCategories).values(
                         [{"user_id": user_id, "category_id": category_id} for category_id in categories_ids]
                     )


### PR DESCRIPTION
### Что сделано
Убран `refresh()` из метода `create`. Возможно, это он активировал транзакцию после коммита, хотя в документации не нашел ничего об этом. Насколько тестировал, не ломается, но **нужны доп проверки**
### NB!
Не получается ни обновить, ни присвоить те категории, которые не архивные и не родительские (например 11, 12, 13 и 14 подходят, а 21 нет), пользователь при этом создается. Не уверен, правильное ли это поведение