### PR TITLE
Добавление метода для отправки сообщения по 'telegram_id'

### DIFF
--- a/src/api/endpoints/notification.py
+++ b/src/api/endpoints/notification.py
@@ -64,6 +64,8 @@ async def send_user_message(
     ),
 ) -> InfoRate:
     rate = InfoRate()
-    status, notifications.message = await telegram_notification_service.send_message_to_user(telegram_id, notifications)
+    status, notifications.message = await telegram_notification_service.send_message_by_telegram_id(
+        telegram_id, notifications.message
+    )
     rate = telegram_notification_service.count_rate(status, notifications.message, rate)
     return rate

--- a/src/api/services/messages.py
+++ b/src/api/services/messages.py
@@ -36,13 +36,20 @@ class TelegramNotificationService:
         return await self.telegram_notification.send_messages(message=notifications.message, users=users)
 
     async def send_message_to_user(self, id_hash: str, message: str) -> tuple[bool, str]:
-        """Отправляет сообщение указанному по telegram_id пользователю"""
+        """Отправляет сообщение пользователю по указанному id_hash"""
         site_user = await self._session.scalar(select(ExternalSiteUser).where(ExternalSiteUser.id_hash == id_hash))
         if site_user is None:
-            return False, "Пользователя не найден."
+            return False, "Пользователь не найден."
         if site_user.user is None:
             return False, "Телеграм пользователя не найден."
         return await self.telegram_notification.send_message(user_id=site_user.user.telegram_id, message=message)
+
+    async def send_message_by_telegram_id(self, telegram_id: int, message: str) -> tuple[bool, str]:
+        """Отправляет сообщение пользователю по указанному telegram_id"""
+        user = await self._session.scalar(select(User).where(User.telegram_id == telegram_id))
+        if user is None:
+            return False, "Пользователь не найден."
+        return await self.telegram_notification.send_message(user_id=user.telegram_id, message=message)
 
     async def send_messages_to_subscribed_users(self, notifications, category_id, reply_markup=None):
         """Отправляет сообщение всем пользователям, подписанным на заданную категорию.


### PR DESCRIPTION
### Что сделано
Добавлен метод `TelegramNotificationService.send_message_by_telegram_id` для эндпоинта `api/messages/{telegram_id}`.
Теперь для отправки сообщения пользователи определяются по `telegram_id`.

### Как тестировал
Локально проверил работоспособность ендпоинта `api/messages/{telegram_id}`.
Отправлял сообщение на свой `telegram_id`.
Так же проверил, что нельзя отправлять сообщение пользователям которых нет в БД.