### PR TITLE
Исправление отображения списка задач

### DIFF
--- a/src/bot/constants/callback_data.py
+++ b/src/bot/constants/callback_data.py
@@ -1,5 +1,5 @@
-VIEW_TASKS = "view_tasks"
-VIEW_TASKS_AGAIN = "view_tasks_again"
+VIEW_TASKS = "view_tasks!"
+VIEW_TASKS_AGAIN = "view_tasks_again!"
 CHANGE_CATEGORY = "change_category"
 JOB_SUBSCRIPTION = "job_subscription"
 GET_CATEGORIES = "categories_callback"

--- a/src/bot/constants/callback_data.py
+++ b/src/bot/constants/callback_data.py
@@ -1,4 +1,5 @@
 VIEW_TASKS = "view_tasks"
+VIEW_TASKS_AGAIN = "view_tasks_again"
 CHANGE_CATEGORY = "change_category"
 JOB_SUBSCRIPTION = "job_subscription"
 GET_CATEGORIES = "categories_callback"

--- a/src/bot/handlers/tasks.py
+++ b/src/bot/handlers/tasks.py
@@ -78,11 +78,11 @@ async def _view_tasks(
             disable_web_page_preview=True,
             reply_markup=await get_task_info_keyboard(task, ext_site_user),
         )
-    else:
-        context.user_data["last_viewed_id"] = task.id
-        context.user_data["last_viewed_actualizing_time"] = actualizing_time
-        remaining_tasks_count = await task_service.count_user_tasks_actualized_after(user, actualizing_time, task.id)
-        await _show_remaining_tasks_count(update, context, remaining_tasks_count)
+
+    context.user_data["last_viewed_id"] = task.id
+    context.user_data["last_viewed_actualizing_time"] = actualizing_time
+    remaining_tasks_count = await task_service.count_user_tasks_actualized_after(user, actualizing_time, task.id)
+    await _show_remaining_tasks_count(update, context, remaining_tasks_count)
 
 
 async def _show_remaining_tasks_count(update: Update, context: ContextTypes.DEFAULT_TYPE, remaining_tasks_count: int):

--- a/src/bot/keyboards.py
+++ b/src/bot/keyboards.py
@@ -25,6 +25,9 @@ SHOW_MORE_TASKS_BUTTON = [InlineKeyboardButton("Показать ещё зада
 SUPPORT_SERVICE_BUTTON = [
     InlineKeyboardButton("✍ Написать в службу поддержки", callback_data=callback_data.SUPPORT_SERVICE)
 ]
+VIEW_TASKS_AGAIN_BUTTON = [
+    InlineKeyboardButton("Посмотреть задания еще раз", callback_data=callback_data.VIEW_TASKS_AGAIN)
+]
 
 
 def get_personal_account_button(
@@ -130,6 +133,14 @@ async def get_unregistered_user_keyboard() -> InlineKeyboardMarkup:
 
 async def get_back_menu() -> InlineKeyboardMarkup:
     keyboard = [
+        RETURN_MENU_BUTTON,
+    ]
+    return InlineKeyboardMarkup(keyboard)
+
+
+async def get_tasks_list_end_keyboard():
+    keyboard = [
+        VIEW_TASKS_AGAIN_BUTTON,
         RETURN_MENU_BUTTON,
     ]
     return InlineKeyboardMarkup(keyboard)


### PR DESCRIPTION
### Что сделано
1. Сортировка задач для отображения осуществляется по времени актуализации в возрастающем порядке, затем по `id` задачи. Под временем актуализации понимается максимум из (время обновления задачи; время назначения данному пользователю категории, к которой относится задача).
2. После того,  как пользователю отображены очередные N задач, запоминаются время актуализации и `id` последней отображённой задачи. В следующий раз будут показаны первые N из тех задач, время актуализации которых больше запомненного, или равно ему, но `id` больше запомненного. В результате:
  - после изменения задачи она перемещается в конец списка просматриваемых задач независимо от того, была ли она уже просмотрена или нет;
  - новая задача попадает в конец списка;
  - задачи из добавленных пользователю категорий попадают в конец списка;
  - удалённые задачи и задачи из удалённых у пользователя категорий пропадают из списка, никак не влияя на порядок отображения остальных задач.
 3. Добавлена кнопка "Посмотреть задания еще раз" в соответствии с условиями #469
 
### Как тестировал
Локально. Для изменения, добавления, удаления задач использовал страницу документации API. Добавление/удаление категорий у пользователя выполнял в боте.
Проверил правильность отображения списка задач и функционирование кнопок, включая кнопку "Посмотреть задания еще раз", в  случаях, когда:
- список задач пуст (например, все задачи в категориях пользователя заархивированы);
- список задач содержит более N задач (N=3).

Проверил правильность отображения задач в случаях, когда:
- происходит изменение задачи (уже просмотренной и ещё не просмотренной);
- происходит добавление новой задачи или разархивирование старой;
- происходит удаление задачи (уже просмотренной и ещё не просмотренной);
- происходит добавление новой категории пользователю;
- происходит удаление у пользователя категории (тут возможны ситуации, когда уже все задачи из этой категории просмотрены, когда все задачи ещё не просмотрены, а также когда только часть задач просмотрена).

### Замечание
Если обновлять категории пользователя через API, то сначала все категории у него удаляются, а затем назначаются заново, и получается, что задачи из оставшихся категорий формально становятся обновлёнными. Список задач для просмотра в этом случае фактически формируется заново.