### PR TITLE
Добавление эндпойнта для изменения отклика пользователя на задание

### DIFF
--- a/src/api/endpoints/__init__.py
+++ b/src/api/endpoints/__init__.py
@@ -5,7 +5,7 @@ from .external_site_user import site_user_router
 from .feedback import feedback_router
 from .health_check import health_check_router
 from .notification import notification_router_by_admin, notification_router_by_token
-from .tasks import task_read_router, task_write_router, tasks_router
+from .tasks import task_read_router, task_response_router, task_write_router, tasks_router
 from .telegram_webhook import telegram_webhook_router
 from .users import user_router
 
@@ -14,6 +14,7 @@ __all__ = (
     "category_router",
     "health_check_router",
     "task_read_router",
+    "task_response_router",
     "task_write_router",
     "tasks_router",
     "telegram_webhook_router",

--- a/src/api/endpoints/tasks.py
+++ b/src/api/endpoints/tasks.py
@@ -151,11 +151,6 @@ async def change_user_response_to_task(
     user_response_to_task: UserResponseToTaskRequest,
     site_user_service: ExternalSiteUserService = Depends(Provide[Container.api_services_container.site_user_service]),
 ) -> None:
-    if user_response_to_task.status:
-        await site_user_service.create_user_response_to_task(
-            user_response_to_task.user_id, user_response_to_task.task_id
-        )
-    else:
-        await site_user_service.delete_user_response_to_task(
-            user_response_to_task.user_id, user_response_to_task.task_id
-        )
+    await site_user_service.change_user_response_to_task(
+        user_response_to_task.user_id, user_response_to_task.task_id, user_response_to_task.status
+    )

--- a/src/api/endpoints/tasks.py
+++ b/src/api/endpoints/tasks.py
@@ -2,8 +2,8 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, status
 
 from src.api.auth import check_header_contains_token
-from src.api.schemas import TaskRequest, TaskResponse, TasksRequest
-from src.api.services import TaskService
+from src.api.schemas import TaskRequest, TaskResponse, TasksRequest, UserResponseToTaskRequest
+from src.api.services import ExternalSiteUserService, TaskService
 from src.api.services.messages import TelegramNotificationService
 from src.bot.keyboards import get_task_info_keyboard
 from src.core.db.models import Task, User
@@ -14,6 +14,7 @@ from src.core.services.notification import TelegramMessageTemplate
 tasks_router = APIRouter(dependencies=[Depends(check_header_contains_token)])
 task_read_router = APIRouter()
 task_write_router = APIRouter(dependencies=[Depends(check_header_contains_token)])
+task_response_router = APIRouter(dependencies=[Depends(check_header_contains_token)])
 
 
 class TaskInfoMessageTemplate(TelegramMessageTemplate):
@@ -142,3 +143,19 @@ async def delete_task(
     task_service: TaskService = Depends(Provide[Container.api_services_container.task_service]),
 ) -> None:
     await task_service.archive(task_id)
+
+
+@task_response_router.post("", description="Изменяет отклик пользователя на задачу.")
+@inject
+async def change_user_response_to_task(
+    user_response_to_task: UserResponseToTaskRequest,
+    site_user_service: ExternalSiteUserService = Depends(Provide[Container.api_services_container.site_user_service]),
+) -> None:
+    if user_response_to_task.status:
+        await site_user_service.create_user_response_to_task(
+            user_response_to_task.user_id, user_response_to_task.task_id
+        )
+    else:
+        await site_user_service.delete_user_response_to_task(
+            user_response_to_task.user_id, user_response_to_task.task_id
+        )

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -10,6 +10,7 @@ from src.api.endpoints import (
     notification_router_by_token,
     site_user_router,
     task_read_router,
+    task_response_router,
     task_write_router,
     tasks_router,
     telegram_webhook_router,
@@ -27,6 +28,7 @@ api_router.include_router(notification_router_by_admin, prefix="/messages", tags
 api_router.include_router(tasks_router, prefix="/tasks", tags=["Content"])
 api_router.include_router(task_read_router, prefix="/task", tags=["Content"])
 api_router.include_router(task_write_router, prefix="/task", tags=["Content"])
+api_router.include_router(task_response_router, prefix="/task_response", tags=["Content"])
 api_router.include_router(telegram_webhook_router, prefix="/telegram", tags=["Telegram"])
 api_router.include_router(admin_user_router, prefix="/auth", tags=["AdminUser"])
 api_router.include_router(site_user_router, prefix="/auth", tags=["ExternalSiteUser"])

--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -13,7 +13,7 @@ from .notification import (
     TelegramNotificationUsersGroups,
     TelegramNotificationUsersRequest,
 )
-from .tasks import TaskRequest, TaskResponse, TasksRequest
+from .tasks import TaskRequest, TaskResponse, TasksRequest, UserResponseToTaskRequest
 from .token_schemas import TokenCheckResponse
 from .users import UserResponse, UsersPaginatedResponse
 
@@ -46,5 +46,6 @@ __all__ = (
     "TokenCheckResponse",
     "FeedbackSchema",
     "UserResponse",
+    "UserResponseToTaskRequest",
     "UsersPaginatedResponse",
 )

--- a/src/api/schemas/tasks.py
+++ b/src/api/schemas/tasks.py
@@ -97,6 +97,8 @@ class TaskResponse(ResponseBase, TaskCommonFieldsMixin):
 
 
 class UserResponseToTaskRequest(RequestBase):
+    """Схема запроса на изменение отклика пользователя на задачу."""
+
     user_id: int
     task_id: int
     status: UserResponseAction

--- a/src/api/schemas/tasks.py
+++ b/src/api/schemas/tasks.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field, PositiveInt, RootModel, StrictFloat, fiel
 
 from src.api.constants import DATE_FORMAT, DATE_FORMAT_FOR_TASK_SCHEMA
 from src.api.schemas.base import RequestBase, ResponseBase
+from src.core.enums import UserResponseAction
 
 
 class TaskDescriptionMain(RequestBase, ResponseBase):
@@ -93,3 +94,9 @@ class TaskResponse(ResponseBase, TaskCommonFieldsMixin):
         PositiveInt | None, Field(..., examples=[1], description="ID дочерней категории, к которой относится задача.")
     ]
     is_archived: bool = Field(..., examples=[False], description="Является ли задача архивной.")
+
+
+class UserResponseToTaskRequest(RequestBase):
+    user_id: int
+    task_id: int
+    status: UserResponseAction

--- a/src/api/services/external_site_user.py
+++ b/src/api/services/external_site_user.py
@@ -2,6 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.schemas import ExternalSiteFundRequest, ExternalSiteVolunteerRequest
 from src.core.db.repository import ExternalSiteUserRepository, TaskRepository, UserRepository
+from src.core.enums import UserResponseAction
 from src.core.exceptions import BadRequestException
 
 
@@ -46,16 +47,11 @@ class ExternalSiteUserService:
         """Архивирует пользователя сайта и удаляет его связь с ботом."""
         await self._site_user_repository.archive(external_id)
 
-    async def create_user_response_to_task(self, site_user_id: int, task_id: int) -> None:
-        """Создаёт отклик заданного пользователя на заданную задачу."""
+    async def change_user_response_to_task(self, site_user_id: int, task_id: int, action: UserResponseAction) -> None:
+        """Изменяет отклик заданного пользователя на заданную задачу."""
         site_user = await self._site_user_repository.get_by_external_id(site_user_id)
         task = await self._task_repository.get(task_id)
-        if not await self._site_user_repository.user_responded_to_task(site_user, task):
+        if action is UserResponseAction.RESPOND:
             await self._site_user_repository.create_user_response_to_task(site_user, task)
-
-    async def delete_user_response_to_task(self, site_user_id: int, task_id: int) -> None:
-        """Отменяет отклик заданного пользователя на заданную задачу."""
-        site_user = await self._site_user_repository.get_by_external_id(site_user_id)
-        task = await self._task_repository.get(task_id)
-        if await self._site_user_repository.user_responded_to_task(site_user, task):
+        else:
             await self._site_user_repository.delete_user_response_to_task(site_user, task)

--- a/src/api/services/external_site_user.py
+++ b/src/api/services/external_site_user.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.schemas import ExternalSiteFundRequest, ExternalSiteVolunteerRequest
-from src.core.db.repository import ExternalSiteUserRepository, UserRepository
+from src.core.db.repository import ExternalSiteUserRepository, TaskRepository, UserRepository
 from src.core.exceptions import BadRequestException
 
 
@@ -12,10 +12,12 @@ class ExternalSiteUserService:
         self,
         user_repository: UserRepository,
         site_user_repository: ExternalSiteUserRepository,
+        task_repository: TaskRepository,
         session: AsyncSession,
     ) -> None:
         self._user_repository: UserRepository = user_repository
         self._site_user_repository: ExternalSiteUserRepository = site_user_repository
+        self._task_repository: TaskRepository = task_repository
         self._session: AsyncSession = session
 
     async def register(self, site_user_schema: ExternalSiteVolunteerRequest | ExternalSiteFundRequest) -> None:
@@ -43,3 +45,17 @@ class ExternalSiteUserService:
     async def archive(self, external_id: int) -> None:
         """Архивирует пользователя сайта и удаляет его связь с ботом."""
         await self._site_user_repository.archive(external_id)
+
+    async def create_user_response_to_task(self, site_user_id: int, task_id: int) -> None:
+        """Создаёт отклик заданного пользователя на заданную задачу."""
+        site_user = await self._site_user_repository.get_by_external_id(site_user_id)
+        task = await self._task_repository.get(task_id)
+        if not await self._site_user_repository.user_responded_to_task(site_user, task):
+            await self._site_user_repository.create_user_response_to_task(site_user, task)
+
+    async def delete_user_response_to_task(self, site_user_id: int, task_id: int) -> None:
+        """Отменяет отклик заданного пользователя на заданную задачу."""
+        site_user = await self._site_user_repository.get_by_external_id(site_user_id)
+        task = await self._task_repository.get(task_id)
+        if await self._site_user_repository.user_responded_to_task(site_user, task):
+            await self._site_user_repository.delete_user_response_to_task(site_user, task)

--- a/src/core/depends/api_services.py
+++ b/src/core/depends/api_services.py
@@ -29,6 +29,7 @@ class APIServicesContainer(containers.DeclarativeContainer):
         ExternalSiteUserService,
         user_repository=repositories.user_repository,
         site_user_repository=repositories.site_user_repository,
+        task_repository=repositories.task_repository,
         session=data_base_connection.session,
     )
     category_service = providers.Factory(

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -10,6 +10,20 @@ class TelegramNotificationUsersGroups(StrEnum):
     UNSUBSCRIBED = "unsubscribed"
 
 
+class UserResponseAction(StrEnum):
+    """Типы действий с откликом пользователя на задачу.
+
+    - respond: создать отклик;
+    - unrespond: удалить отклик.
+    """
+
+    RESPOND = "respond"
+    UNRESPOND = "cancel_respond"
+
+    def __bool__(self):
+        return self.name == "RESPOND"
+
+
 class UserRoles(StrEnum):
     """Роли пользователя в системе.
 

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -20,9 +20,6 @@ class UserResponseAction(StrEnum):
     RESPOND = "respond"
     UNRESPOND = "cancel_respond"
 
-    def __bool__(self):
-        return self.name == "RESPOND"
-
 
 class UserRoles(StrEnum):
     """Роли пользователя в системе.


### PR DESCRIPTION
### Что сделано
Добавлен эндпойнт для изменения отклика пользователя на задание в соответствии с условиями #557.

### Как проверял
Локально. Обращение к API через страницу документации, просмотр БД с помощью DBeaver.

Проверил, что эндпойнт требует передачи токена сайта.

Для `status="respond`" проверил, что:
- если пользователь сайта с заданным `user_id` и задача с заданным `task_id` есть в БД бота, то создаётся соответствующий отклик, если его ещё нет в БД. А если такой отклик уже есть, то ничего не происходит;
- если пользователь сайта с заданным `user_id` или задача с заданным `task_id` отсутствуют в БД бота, то возвращается 404.

Для `status="cancel_respond"` проверил, что:
- если пользователь сайта с заданным `user_id` и задача с заданным `task_id` есть в БД бота, то соответствующий отклик удаляется из БД, если он там есть. А если такого отклика в БД нет, то ничего не происходит;
- если пользователь сайта с заданным `user_id` или задача с заданным `task_id` отсутствуют в БД бота, то возвращается 404.

Проверил, что неправильное значение в поле `status` приводит к ошибке 422.