### PR TITLE
Добавление эндпойнта для получения списка админов

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ ProCharity (НКО Фонд Друзья).
     docker exec -it procharity_bot_backend sh -c "alembic upgrade head && python3 fill_db.py"
     ```
 
+    Если в тестовую базу нужно добавить пользователей-админов, то необходимо выполнить команду:
+
+    ```shell
+    docker exec -it procharity_bot_backend sh -c "alembic upgrade head && python3 fill_db.py add_fake_admins"
+    ```
+
 ## Для разработки
 
 ### Установка и настройка приложения
@@ -191,6 +197,12 @@ ProCharity (НКО Фонд Друзья).
 
     ```shell
     python3 fill_db.py with_fake_users
+    ```
+
+    Генерация тестовых данных c таблицей пользователей и таблицей админов
+
+    ```shell
+    python3 fill_db.py with_fake_users add_fake_admins
     ```
 
 4. Запустить сервер приложения.

--- a/fill_db.py
+++ b/fill_db.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.bot.constants import enum
 from src.core.db import get_session
-from src.core.db.models import Category, ExternalSiteUser, Task, UnsubscribeReason, User
+from src.core.db.models import AdminUser, Category, ExternalSiteUser, Task, UnsubscribeReason, User
 from src.core.enums import UserRoles, UserStatus
 
 CHARACTERS = string.ascii_uppercase + string.digits
@@ -159,6 +159,7 @@ TEST_TASKS = [
     },
 ]
 USERS_TABLE_ROWS = 30
+FAKE_ADMINS_COUNT = 30
 
 
 async def get_task_name_by_id(category_id):
@@ -313,7 +314,22 @@ async def delete_all_data(
     await session.commit()
 
 
-async def run(generate_fake_users: bool):
+async def add_admin_users(start: int, count: int, session: async_sessionmaker[AsyncSession]):
+    for n in range(start, start + count):
+        admin_user = AdminUser(
+            email=f"admin-{n}@example.com",
+            first_name=f"Эдик-{n}",
+            last_name="Минов",
+            hashed_password="1234567890",
+            is_active=True,
+            is_superuser=False,
+            is_verified=False,
+        )
+        session.add(admin_user)
+        await session.commit()
+
+
+async def run(generate_fake_users: bool, add_fake_admins: bool):
     session_manager = asynccontextmanager(get_session)
     async with session_manager() as session:
         await delete_all_data(session)
@@ -323,9 +339,16 @@ async def run(generate_fake_users: bool):
         if generate_fake_users:
             await filling_user_and_external_site_user_in_db(session)
             await filling_unsubscribe_reason_in_db(session)
+        if add_fake_admins:
+            await add_admin_users(1, FAKE_ADMINS_COUNT, session)
         print("Тестовые данные загружены в БД.")
 
 
 if __name__ == "__main__":
-    generate_fake_users = "with_fake_users" in sys.argv[1:]
-    asyncio.run(run(generate_fake_users))
+    options = sys.argv[1:]
+    asyncio.run(
+        run(
+            "with_fake_users" in options,
+            "add_fake_admins" in options,
+        )
+    )

--- a/src/api/endpoints/admin/__init__.py
+++ b/src/api/endpoints/admin/__init__.py
@@ -8,6 +8,7 @@ from src.api.permissions import is_active_user
 from src.api.schemas.admin import AdminUserCreate, AdminUserRead, AdminUserUpdate
 
 from .invitation import invitation_router
+from .list import admin_user_list_router
 
 admin_router = APIRouter(
     dependencies=[Depends(is_active_user)],
@@ -16,6 +17,8 @@ admin_router = APIRouter(
 admin_router.include_router(analytic_router, prefix="/analytics", tags=["Analytic"])
 admin_router.include_router(notification_router_by_admin, prefix="/messages", tags=["Messages"])
 admin_router.include_router(user_router, prefix="/users", tags=["User"])
+admin_router.include_router(admin_user_list_router, prefix="/admins", tags=["Admins"])
+
 
 admin_auth_router = APIRouter()
 admin_auth_router.include_router(fastapi_admin_users.get_auth_router(auth_backend))

--- a/src/api/endpoints/admin/list.py
+++ b/src/api/endpoints/admin/list.py
@@ -1,0 +1,17 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.api.schemas import AdminUserRead
+from src.api.services import AdminService
+from src.core.db.models import AdminUser
+from src.core.depends import Container
+
+admin_user_list_router = APIRouter()
+
+
+@admin_user_list_router.get("", response_model=list[AdminUserRead])
+@inject
+async def list_admin_users(
+    admin_user_service: AdminService = Depends(Provide[Container.api_services_container.admin_service]),
+) -> list[AdminUser]:
+    return await admin_user_service.get_all()

--- a/src/api/endpoints/admin/list.py
+++ b/src/api/endpoints/admin/list.py
@@ -1,17 +1,27 @@
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, Request
 
-from src.api.schemas import AdminUserRead
+from src.api.pagination import AdminUserPaginator
+from src.api.schemas import AdminUsersPaginatedRead
 from src.api.services import AdminService
-from src.core.db.models import AdminUser
 from src.core.depends import Container
 
 admin_user_list_router = APIRouter()
 
 
-@admin_user_list_router.get("", response_model=list[AdminUserRead])
+@admin_user_list_router.get(
+    "",
+    response_model=AdminUsersPaginatedRead,
+    response_model_exclude_none=True,
+    description="Получает список всех администраторов.",
+)
 @inject
 async def list_admin_users(
+    request: Request,
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1),
     admin_user_service: AdminService = Depends(Provide[Container.api_services_container.admin_service]),
-) -> list[AdminUser]:
-    return await admin_user_service.get_all()
+    admin_user_paginator: AdminUserPaginator = Depends(Provide[Container.api_paginate_container.admin_user_paginate]),
+) -> AdminUsersPaginatedRead:
+    admin_users = await admin_user_service.get_admin_users_by_page(page, limit)
+    return await admin_user_paginator.paginate(admin_users, page, limit, request.url.path)

--- a/src/api/pagination.py
+++ b/src/api/pagination.py
@@ -1,8 +1,8 @@
 import math
 from typing import Any, Generic, TypeVar
 
-from src.core.db.models import User
-from src.core.db.repository import AbstractRepository, UserRepository
+from src.core.db.models import AdminUser, User
+from src.core.db.repository import AbstractRepository, AdminUserRepository, UserRepository
 from src.core.db.repository.base import FilterableRepository
 
 DatabaseModel = TypeVar("DatabaseModel")
@@ -53,6 +53,13 @@ class FilterablePaginator(BasePaginator, Generic[DatabaseModel]):
     ) -> dict:
         total_objects_count = await self.repository.count_by_filter(filter_by)
         return self._get_paginated_dict(total_objects_count, objects, page, limit, url)
+
+
+class AdminUserPaginator(BasePaginator[AdminUser]):
+    """Класс для пагинации данных из модели AdminUser."""
+
+    def __init__(self, repository: AdminUserRepository) -> None:
+        super().__init__(repository)
 
 
 class UserPaginator(FilterablePaginator[User]):

--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -1,3 +1,4 @@
+from .admin import AdminUserRead
 from .analytics import ActiveTasks, AllUsersStatistic, Analytic, ReasonCancelingStatistics
 from .base import RequestBase, ResponseBase
 from .categories import CategoryRequest, CategoryResponse
@@ -25,6 +26,7 @@ from .users import UserResponse, UsersPaginatedResponse
 
 __all__ = (
     "ActiveTasks",
+    "AdminUserRead",
     "AllUsersStatistic",
     "Analytic",
     "RequestBase",

--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .admin import AdminUserRead
+from .admin import AdminUserRead, AdminUsersPaginatedRead
 from .analytics import ActiveTasks, AllUsersStatistic, Analytic, ReasonCancelingStatistics
 from .base import RequestBase, ResponseBase
 from .categories import CategoryRequest, CategoryResponse
@@ -27,6 +27,7 @@ from .users import UserResponse, UsersPaginatedResponse
 __all__ = (
     "ActiveTasks",
     "AdminUserRead",
+    "AdminUsersPaginatedRead",
     "AllUsersStatistic",
     "Analytic",
     "RequestBase",

--- a/src/api/schemas/admin.py
+++ b/src/api/schemas/admin.py
@@ -1,4 +1,5 @@
 import re
+from datetime import date
 from typing import Never
 
 from fastapi.param_functions import Form
@@ -24,7 +25,9 @@ class AdminUserCreate(schemas.CreateUpdateDictModel):
 
 
 class AdminUserRead(schemas.BaseUser[int]):
-    pass
+    first_name: str
+    last_name: str
+    last_login: date
 
 
 class AdminUserUpdate(schemas.BaseUserUpdate):

--- a/src/api/schemas/admin.py
+++ b/src/api/schemas/admin.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, EmailStr, Field, ValidationInfo, field_validator
 from src.api.constants import PASSWORD_POLICY
 from src.core.exceptions import InvalidPassword, NullException
 
+from .base import PaginateBase
+
 
 class AdminUserCreate(schemas.CreateUpdateDictModel):
     token: str = Field(..., description="Invitation token.")
@@ -25,9 +27,13 @@ class AdminUserCreate(schemas.CreateUpdateDictModel):
 
 
 class AdminUserRead(schemas.BaseUser[int]):
-    first_name: str
-    last_name: str
-    last_login: date
+    first_name: str | None
+    last_name: str | None
+    last_login: date | None
+
+
+class AdminUsersPaginatedRead(PaginateBase):
+    result: list[AdminUserRead] | None
 
 
 class AdminUserUpdate(schemas.BaseUserUpdate):

--- a/src/api/services/admin_service.py
+++ b/src/api/services/admin_service.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from jose import JWTError, jwt
 
 from src.core.db.models import AdminUser
@@ -11,6 +13,9 @@ class AdminService:
 
     def __init__(self, admin_repository: AdminUserRepository) -> None:
         self._repository: AdminUserRepository = admin_repository
+
+    async def get_all(self) -> Sequence[AdminUser]:
+        return await self._repository.get_all()
 
     async def authenticate_user(self, email: str, password: str) -> AdminUser | None:
         user = await self._repository.get_by_email(email)

--- a/src/api/services/admin_service.py
+++ b/src/api/services/admin_service.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 from jose import JWTError, jwt
 
 from src.core.db.models import AdminUser
@@ -14,8 +12,8 @@ class AdminService:
     def __init__(self, admin_repository: AdminUserRepository) -> None:
         self._repository: AdminUserRepository = admin_repository
 
-    async def get_all(self) -> Sequence[AdminUser]:
-        return await self._repository.get_all()
+    async def get_admin_users_by_page(self, page: int, limit: int) -> dict:
+        return await self._repository.get_objects_by_page(page, limit)
 
     async def authenticate_user(self, email: str, password: str) -> AdminUser | None:
         user = await self._repository.get_by_email(email)

--- a/src/core/depends/pagination.py
+++ b/src/core/depends/pagination.py
@@ -1,6 +1,6 @@
 from dependency_injector import containers, providers
 
-from src.api.pagination import UserPaginator
+from src.api.pagination import AdminUserPaginator, UserPaginator
 
 
 class PaginateContainer(containers.DeclarativeContainer):
@@ -11,4 +11,9 @@ class PaginateContainer(containers.DeclarativeContainer):
     user_paginate = providers.Factory(
         UserPaginator,
         user_repository=repositories.user_repository,
+    )
+
+    admin_user_paginate = providers.Factory(
+        AdminUserPaginator,
+        repository=repositories.admin_repository,
     )


### PR DESCRIPTION
### Что сделано
1. Добавлен эндпойнт для получения списка админов, как указано в #617.
2. Для целей тестирования в скрипт `fill_db.py` добавлена опция `add_fake_admins` для добавления в БД админов. Админы именно добавляются - таблица `admin_users` не очищается. Данные админов не случайные - так гораздо удобнее для тестирования. Добавляются по одному, чтобы отличались временем создания. Добавляется 30 админов, но при нужде константу `FAKE_ADMINS_COUNT` можно руками поправить.

### Как тестировал
Локально. К API обращался через страницу документации. Для просмотра и изменения БД использовал DBeaver.
1. Создал активного суперпользователя админки, как указано в п.1 комментария https://github.com/Studio-Yandex-Practicum/ProCharity_back_2.0/issues/596#issuecomment-2233657507 и залогинил его с помощью cookies.
2. Добавил в БД админов: `python3 fill_db.py add_fake_admins`.
3. Проверил наличие в API эндпойнта для получения списка админов, и что он требует авторизации пользователя.
4. Проверил правильность его работы при различных параметрах пагинации.
5. Проверил, что эндпойнт доступен также для админа, не являющегося суперпользователем.
6. Проверил, что все работает, если у какого-либо админа `last_name` или `first_name` равно `NULL`.