### PR TITLE
Добавление полей для настроек уведомлений в эндпоинты ExternalSiteUser

### DIFF
--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -5,7 +5,6 @@ from .categories import CategoryRequest, CategoryResponse
 from .external_site_user import (
     ExternalSiteFundPartialUpdate,
     ExternalSiteFundRequest,
-    ExternalSiteUser,
     ExternalSiteVolunteerPartialUpdate,
     ExternalSiteVolunteerRequest,
 )

--- a/src/api/schemas/external_site_user.py
+++ b/src/api/schemas/external_site_user.py
@@ -1,7 +1,6 @@
 from pydantic import EmailStr, Field, field_validator
 
 from src.api.schemas.base import RequestBase
-from src.core.db.models import ExternalSiteUser
 from src.core.enums import UserRoles, UserStatus
 
 
@@ -12,6 +11,10 @@ class BaseExternalSiteUser(RequestBase):
     last_name: str | None = Field(None, max_length=64)
     email: EmailStr | None = Field(None, max_length=48)
     moderation_status: str | None = Field(None)
+    has_mailing_new_tasks: bool | None = Field(None)
+    has_mailing_profile: bool | None = Field(None)
+    has_mailing_my_tasks: bool | None = Field(None)
+    has_mailing_procharity: bool | None = Field(None)
 
     @field_validator("moderation_status")
     @classmethod
@@ -49,22 +52,12 @@ class BaseExternalSiteUserVolunteer(RequestBase):
 class ExternalSiteUserRequest(BaseExternalSiteUser):
     """Класс схемы запроса для ExternalSiteUser."""
 
-    user_id: int = Field(..., gt=0)
+    external_id: int = Field(..., gt=0, alias="user_id")
     id_hash: str = Field(..., min_length=1, max_length=256)
     first_name: str = Field(..., max_length=64)
     last_name: str = Field(..., max_length=64)
     email: EmailStr = Field(..., max_length=48)
     moderation_status: str = Field(...)
-
-    def to_orm(self) -> ExternalSiteUser:
-        return ExternalSiteUser(
-            external_id=self.user_id,
-            id_hash=self.id_hash,
-            first_name=self.first_name,
-            last_name=self.last_name,
-            email=self.email,
-            moderation_status=self.moderation_status,
-        )
 
 
 class ExternalSiteVolunteerRequest(ExternalSiteUserRequest, BaseExternalSiteUserVolunteer):
@@ -72,21 +65,15 @@ class ExternalSiteVolunteerRequest(ExternalSiteUserRequest, BaseExternalSiteUser
 
     specializations: list[int]
 
-    def to_orm(self) -> ExternalSiteUser:
-        user_orm = super().to_orm()
-        user_orm.role = UserRoles.VOLUNTEER
-        user_orm.specializations = self.specializations
-        return user_orm
+    def get_role(self) -> UserRoles:
+        return UserRoles.VOLUNTEER
 
 
 class ExternalSiteFundRequest(ExternalSiteUserRequest):
     """Класс схемы запроса для ExternalSiteUser (Fund)."""
 
-    def to_orm(self) -> ExternalSiteUser:
-        user_orm = super().to_orm()
-        user_orm.role = UserRoles.FUND
-        user_orm.specializations = None
-        return user_orm
+    def get_role(self) -> UserRoles:
+        return UserRoles.FUND
 
 
 class ExternalSiteVolunteerPartialUpdate(BaseExternalSiteUser, BaseExternalSiteUserVolunteer):

--- a/src/api/schemas/external_site_user.py
+++ b/src/api/schemas/external_site_user.py
@@ -11,7 +11,6 @@ class BaseExternalSiteUser(RequestBase):
     last_name: str | None = Field(None, max_length=64)
     email: EmailStr | None = Field(None, max_length=48)
     moderation_status: str | None = Field(None)
-    has_mailing_new_tasks: bool | None = Field(None)
     has_mailing_profile: bool | None = Field(None)
     has_mailing_my_tasks: bool | None = Field(None)
     has_mailing_procharity: bool | None = Field(None)
@@ -31,7 +30,8 @@ class BaseExternalSiteUser(RequestBase):
 class BaseExternalSiteUserVolunteer(RequestBase):
     """Базовый класс схемы для ExternalSiteUser (Volunteer)."""
 
-    specializations: list[int] | None = None
+    specializations: list[int] | None = Field(None)
+    has_mailing_new_tasks: bool | None = Field(None)
 
     @field_validator("specializations", mode="before")
     @classmethod

--- a/src/api/schemas/external_site_user.py
+++ b/src/api/schemas/external_site_user.py
@@ -11,9 +11,9 @@ class BaseExternalSiteUser(RequestBase):
     last_name: str | None = Field(None, max_length=64)
     email: EmailStr | None = Field(None, max_length=48)
     moderation_status: str | None = Field(None)
-    has_mailing_profile: bool | None = Field(None)
-    has_mailing_my_tasks: bool | None = Field(None)
-    has_mailing_procharity: bool | None = Field(None)
+    has_mailing_profile: bool = None
+    has_mailing_my_tasks: bool = None
+    has_mailing_procharity: bool = None
 
     @field_validator("moderation_status")
     @classmethod
@@ -31,7 +31,7 @@ class BaseExternalSiteUserVolunteer(RequestBase):
     """Базовый класс схемы для ExternalSiteUser (Volunteer)."""
 
     specializations: list[int] | None = Field(None)
-    has_mailing_new_tasks: bool | None = Field(None)
+    has_mailing_new_tasks: bool = None
 
     @field_validator("specializations", mode="before")
     @classmethod

--- a/src/api/services/external_site_user.py
+++ b/src/api/services/external_site_user.py
@@ -59,7 +59,8 @@ class ExternalSiteUserService:
             user.first_name = site_user.first_name
             user.last_name = site_user.last_name
             user.role = site_user.role
-            user.has_mailing = site_user.has_mailing_new_tasks
+            if site_user.has_mailing_new_tasks:
+                user.has_mailing = site_user.has_mailing_new_tasks
 
             await self._user_repository.update(user.id, user)
             await self._user_repository.set_categories_to_user(user.id, site_user.specializations)
@@ -77,7 +78,8 @@ class ExternalSiteUserService:
 
         user = await self._user_repository.get_by_external_id(site_user.id)
         if user:
-            user.has_mailing = site_user.has_mailing_new_tasks
+            if site_user.has_mailing_new_tasks:
+                user.has_mailing = site_user.has_mailing_new_tasks
             for attr, value in data_for_update.items():
                 setattr(user, attr, value)
 

--- a/src/api/services/external_site_user.py
+++ b/src/api/services/external_site_user.py
@@ -59,7 +59,7 @@ class ExternalSiteUserService:
             user.first_name = site_user.first_name
             user.last_name = site_user.last_name
             user.role = site_user.role
-            if site_user.has_mailing_new_tasks:
+            if site_user.has_mailing_new_tasks is not None:
                 user.has_mailing = site_user.has_mailing_new_tasks
 
             await self._user_repository.update(user.id, user)
@@ -78,7 +78,7 @@ class ExternalSiteUserService:
 
         user = await self._user_repository.get_by_external_id(site_user.id)
         if user:
-            if site_user.has_mailing_new_tasks:
+            if site_user.has_mailing_new_tasks is not None:
                 user.has_mailing = site_user.has_mailing_new_tasks
             for attr, value in data_for_update.items():
                 setattr(user, attr, value)


### PR DESCRIPTION
### Что сделано
Добавил:
1. Новые поля в схему `BaseExternalSiteUser`.
2. `Alias` для поля `external_id`.
3. Методы `get_role` для определения роли.
4. Изменение состояния поля `user.has_mailing` в зависимости от `site_user.has_mailing_new_tasks`.
5. Немного изменил метод `register` в `ExternalSiteUserService`. Мне кажется этот метод можно разделить (для волонтёров и фондов отдельно).

### Как тестировал
Проверил работоспособность эндпоинтов через документацию:
```
post "/api/auth/external_user_registration/volunteer"
post "/api/auth/external_user_registration/fund"
patch "/api/auth/external_user_registration/volunteer/{user_id}"
patch "/api/auth/external_user_registration/fund/{user_id}"
```
Если в новые поля передать `Null`, то это никак не повлияет на значения этих полей в БД.