### PR TITLE
Исправить telegram.error.BadRequest для webapp-ов

### DIFF
--- a/env.example
+++ b/env.example
@@ -48,6 +48,6 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # URLs проекта Procharity
-PROCHARITY_URL=https://test6.procharity.corptest.ru/ # Основной URL проекта
+PROCHARITY_URL=http://test6.procharity.corptest.ru/ # Основной URL проекта
 HELP_PROCHARITY_URL=https://help.procharity.ru/ # URL "Ответы на вопросы" проекта
 ACCESS_TOKEN_SEND_DATA_TO_PROCHARITY= # Токен для обновления данных на сайте

--- a/src/settings.py
+++ b/src/settings.py
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
     @property
     def procharity_task_url(self) -> str:
         """Получить url-ссылку на страницу с информацией о задании."""
-        return urljoin(self.PROCHARITY_URL, "webapp/")
+        return urljoin(self.PROCHARITY_URL.replace("http://", "https://"), "webapp/")
 
     @property
     def procharity_registration_url(self) -> str:


### PR DESCRIPTION
Если у PROCHARITY_URL сертификат http, то при формировании сообщений о заданиях возникает ошибка типа "telegram.error.BadRequest: Inline keyboard button web app url '{PROCHARITY_URL}/webapp/?task_id=123' is invalid: only https links are allowed". Кнопка "Посмотреть актуальные задания" при этом не работает.