### PR TITLE
Исправление бага: при привязке к другой учетке частично остается связь с первой учеткой

### DIFF
--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -28,6 +28,10 @@ async def start_command(
 ):
     telegram_user = update.effective_user or Never
     user = await user_service.register_user(ext_site_user, telegram_user)
+    print("user.external_user.external_id", user.external_user.external_id)
+    print("user.external_id", user.external_id)
+    print("ext_site_user.external_id", ext_site_user.external_id)
+    print("user.first_name", user.first_name)
     auth_url = volunteer_auth_url if user.is_volunteer else fund_auth_url
     you_authorized_phrase = "Ты авторизовался" if user.is_volunteer else "Вы авторизовались"
     await context.bot.send_message(

--- a/src/bot/handlers/registration.py
+++ b/src/bot/handlers/registration.py
@@ -28,10 +28,6 @@ async def start_command(
 ):
     telegram_user = update.effective_user or Never
     user = await user_service.register_user(ext_site_user, telegram_user)
-    print("user.external_user.external_id", user.external_user.external_id)
-    print("user.external_id", user.external_id)
-    print("ext_site_user.external_id", ext_site_user.external_id)
-    print("user.first_name", user.first_name)
     auth_url = volunteer_auth_url if user.is_volunteer else fund_auth_url
     you_authorized_phrase = "Ты авторизовался" if user.is_volunteer else "Вы авторизовались"
     await context.bot.send_message(

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -45,7 +45,10 @@ class UserService(BaseUserService):
         do_update_or_create = False
         if user:
             if user.telegram_id != telegram_id:
-                await self._update_or_create(user, external_id=None)
+                print(user.external_id, user.external_user)
+                # await self._update_or_create(user, external_id=None)
+                await self._update_or_create(user, external_user=None)
+                print(user.external_id, user.external_user)
                 user = user_by_telegram_id
                 do_update_or_create = True
 
@@ -54,16 +57,19 @@ class UserService(BaseUserService):
             do_update_or_create = True
 
         if do_update_or_create:
+            print(user.external_id, user.external_user)
             user = await self._update_or_create(
                 user,
                 telegram_id=telegram_id,
-                external_id=ext_site_user.id,
+                # external_id=ext_site_user.id,
+                external_user=ext_site_user,
                 first_name=ext_site_user.first_name or telegram_user.first_name,
                 last_name=ext_site_user.last_name or telegram_user.last_name,
                 username=telegram_user.username,
                 email=ext_site_user.email,
                 role=ext_site_user.role,
             )
+            print(user.external_id, user.external_user)
             await logger.ainfo(f"Обновлены данные пользователя {user=}")
             await self.set_categories_to_user(user.id, ext_site_user.specializations)
 

--- a/src/bot/services/user.py
+++ b/src/bot/services/user.py
@@ -45,10 +45,7 @@ class UserService(BaseUserService):
         do_update_or_create = False
         if user:
             if user.telegram_id != telegram_id:
-                print(user.external_id, user.external_user)
-                # await self._update_or_create(user, external_id=None)
                 await self._update_or_create(user, external_user=None)
-                print(user.external_id, user.external_user)
                 user = user_by_telegram_id
                 do_update_or_create = True
 
@@ -57,11 +54,9 @@ class UserService(BaseUserService):
             do_update_or_create = True
 
         if do_update_or_create:
-            print(user.external_id, user.external_user)
             user = await self._update_or_create(
                 user,
                 telegram_id=telegram_id,
-                # external_id=ext_site_user.id,
                 external_user=ext_site_user,
                 first_name=ext_site_user.first_name or telegram_user.first_name,
                 last_name=ext_site_user.last_name or telegram_user.last_name,
@@ -69,7 +64,6 @@ class UserService(BaseUserService):
                 email=ext_site_user.email,
                 role=ext_site_user.role,
             )
-            print(user.external_id, user.external_user)
             await logger.ainfo(f"Обновлены данные пользователя {user=}")
             await self.set_categories_to_user(user.id, ext_site_user.specializations)
 


### PR DESCRIPTION
Во всех местах, где возникали баги, использовался user.external_user. Проблема была в том, что после привязки к другому пользователю сайта user.external_user оставался не обновленным и продолжал ссылаться на первого пользователя сайта.
При передаче external_id=ext_site_user.id в _update_or_create происходило обновление только user.external_id, но не user.external_user.
В исправленном варианте в _update_or_create передается external_user=ext_site_user. В результате обновляется и user.external_id, и user.external_user.

### Что сделано
1. Исправлено обновление external_user у user при привязке пользователя Телеграм к другой учетке внешнего сайта.
2. Исправлено обнуление связи другого пользователя Телеграм и учетки внешнего сайта при привязке первого пользователя Телеграм к учетке внешнего сайта, к которой был привязан другой пользователь Телеграм.


### Как проверяла
1. Добавила печать user.external_user.external_id, user.external_id, ext_site_user.external_id, user.first_name, user.external_user, чтобы смотреть, как меняются значения при привязке к другой учетке.
**Для удобства тестирования оставила в коде принты и старую версию кода. Перед мержем удалю их.**

2. На примере отображения настроек уведомлений по кнопке "Изменить настройку уведомлений" (пункт 3 в описании задачи):
- изменила SHOW_NOTIFICATION_SETTINGS_MENU: bool = True;
- создала несколько пользователей сайта с разным набором true / false в has_mailing_profile, has_mailing_my_tasks, has_mailing_procharity;
- привязывалась к разным пользователям сайта и проверяла изменение галочек.