### PR TITLE
Добавление обработчиков сообщений от пользователя

### DIFF
--- a/src/bot/handlers/user_messages.py
+++ b/src/bot/handlers/user_messages.py
@@ -1,0 +1,57 @@
+from telegram import Update
+from telegram.ext import Application, ContextTypes, MessageHandler, filters
+
+from src.bot.utils import registered_user_required
+from src.core.db.models import ExternalSiteUser
+from src.core.logging.utils import logger_decor
+
+ALLOWED_MESSAGES_FILTER = (
+    filters.TEXT
+    | filters.VOICE
+    | filters.Document.ALL
+    | filters.PHOTO
+    | filters.VIDEO
+    | filters.VIDEO_NOTE
+    | filters.AUDIO
+    | filters.Sticker.ALL
+) & ~filters.ANIMATION
+
+DISALLOWED_MESSAGES_FILTER = filters.LOCATION | filters.POLL | filters.CONTACT | filters.ANIMATION
+
+
+@logger_decor
+@registered_user_required
+async def allowed_messages_callback(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
+):
+    print(type(update.message.effective_attachment))
+    filling = ("твои", "") if ext_site_user.user.is_volunteer else ("ваши", "те")
+    text = (
+        "Пока что мы не можем получать {} сообщения через бот — "
+        "пожалуйста, пиши{} нам через форму обратной связи. "
+        'Ее можно найти в меню бота по кнопке "✍ Написать в службу поддержки".'
+    ).format(*filling)
+    await update.effective_message.reply_text(text)
+
+
+@logger_decor
+@registered_user_required
+async def disallowed_messages_callback(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    ext_site_user: ExternalSiteUser,
+):
+    filling = ("",) if ext_site_user.user.is_volunteer else ("те",)
+    text = (
+        "Такие сообщения бот не принимает — "
+        "пожалуйста, пиши{} нам через форму обратной связи. "
+        'Ее можно найти в меню бота по кнопке "✍ Написать в службу поддержки".'
+    ).format(*filling)
+    await update.effective_message.reply_text(text)
+
+
+def registration_handlers(app: Application):
+    app.add_handler(MessageHandler(ALLOWED_MESSAGES_FILTER, allowed_messages_callback))
+    app.add_handler(MessageHandler(DISALLOWED_MESSAGES_FILTER, disallowed_messages_callback))

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -7,12 +7,13 @@ from src.core.logging.utils import logging_updates
 def init_bot(telegram_bot: Application) -> Application:
     """Инициализация телеграм бота."""
 
-    from .handlers import categories, menu, notifications, registration, tasks
+    from .handlers import categories, menu, notifications, registration, tasks, user_messages
 
     registration.registration_handlers(telegram_bot)
     categories.registration_handlers(telegram_bot)
     notifications.registration_handlers(telegram_bot)
     tasks.registration_handlers(telegram_bot)
     menu.registration_handlers(telegram_bot)
+    user_messages.registration_handlers(telegram_bot)
     telegram_bot.add_handler(TypeHandler(Update, logging_updates))
     return telegram_bot


### PR DESCRIPTION
### Что сделано
Добавлены два обработчика сообщений от пользователя: один для разрешённых типов сообщений, другой для запрещённых. Обрабатываемые типы сообщений и выводимые ответные сообщения - в соответствии с условиями задачи #686.

### Как проверял
Локально. 
1. Зарегистрировался в боте как волонтер и проверил правильность реакции на все предусмотренные типы сообщений.
2.  Зарегистрировался в боте как фонд и проверил правильность реакции на все предусмотренные типы сообщений.
3. Зашёл в бот с незарегистрированной в боте учётки Телеграм и проверил, что при отправке сообщений в бот, как разрешённых, так и запрещённых типов, выводится приглашение зарегистрироваться.